### PR TITLE
Tie secrets to resource IDs for better cleanup

### DIFF
--- a/state_test.go
+++ b/state_test.go
@@ -27,7 +27,7 @@ func TestState(t *testing.T) {
 			description: "state works",
 			stateID:     testStateID,
 			expectedJSON: strings.TrimSpace(`
-{"providers":[{"type":"random","resources":[{"id":"fake.state.id","expiration":"2020-01-30T12:00:00Z","deposed":false}]}],"stores":[{"type":"inprocess","secrets":[{"path":"fake.store.path","expiration":"2020-01-30T12:00:00Z"}]}]}
+{"providers":[{"type":"random","resources":[{"id":"fake.state.id","expiration":"2020-01-30T12:00:00Z","deposed":false}]}],"stores":[{"type":"inprocess","secrets":[{"resource_id":"fake.state.id","path":"fake.store.path","expiration":"2020-01-30T12:00:00Z"}]}]}
 `),
 			expectedFinalJSON: strings.TrimSpace(`
 {"providers":[{"type":"random","resources":[]}],"stores":[{"type":"inprocess","secrets":[]}]}
@@ -44,6 +44,7 @@ func TestState(t *testing.T) {
 				Expiration: fixedTestTime,
 			})
 			state.AddSecret(sidecred.Inprocess, &sidecred.Secret{
+				ResourceID: tc.stateID,
 				Path:       "fake.store.path",
 				Expiration: fixedTestTime,
 			})


### PR DESCRIPTION
This PR adds the resource ID to the state entry for secrets. This allows for better cleanup since we can delete orphaned secrets (the ones without valid resource IDs), and we can delete secrets immediately instead of waiting for their expiration.

Ref this:
```
// TODO: Figure out why this is needed -_-
```

I used to get duplicate log entries when deleting resources, so it would say e.g. that it had deleted two access tokens instead of an access token and a deploy key (ref the config in `testadata/`), and I believe it actually attempted to delete the same resource twice. Not 100% sure about why this was happening since there are no deferred calls that might get confused about the pointers, but forcing a local copy with `r := resource` has solved it.

Contributing factors:
- We are iterating over `[]*Resource` which means each iter item is a `*Resource`.
- `range` keyword actually reuses the assigned variable, which leads to surprising behaviours when used with pointers.
- We are using the `*Resource` pointer to delete resources from the state, inside the loop 😅 
