### PR TITLE
Fix resource and secret cleanup issue

### DIFF
--- a/sidecred.go
+++ b/sidecred.go
@@ -246,10 +246,11 @@ Loop:
 	}
 
 	for _, ps := range state.Providers {
-		// Reverse loop to handle index changes due to deleting items in the underlying array.
+		// Reverse loop to handle index changes due to deleting items in the
+		// underlying array: https://stackoverflow.com/a/29006008
 		for i := len(ps.Resources) - 1; i >= 0; i-- {
-			r := ps.Resources[i]
-			if r.InUse && !r.Deposed && r.Expiration.After(time.Now()) {
+			resource := ps.Resources[i]
+			if resource.InUse && !resource.Deposed && resource.Expiration.After(time.Now()) {
 				continue
 			}
 			provider, ok := s.providers[ps.Type]
@@ -259,24 +260,24 @@ Loop:
 			}
 			log := s.logger.With(
 				zap.String("type", string(ps.Type)),
-				zap.String("id", r.ID),
+				zap.String("id", resource.ID),
 			)
 			log.Info("destroying expired resource")
-			if err := provider.Destroy(r); err != nil {
+			if err := provider.Destroy(resource); err != nil {
 				log.Error("destroy resource", zap.Error(err))
 			}
-			state.RemoveResource(provider.Type(), r)
+			state.RemoveResource(provider.Type(), resource)
 		}
 	}
 
 	orphans := state.ListOrphanedSecrets(s.store.Type())
 	for i := len(orphans) - 1; i >= 0; i-- {
-		r := orphans[i]
-		log.Info("deleting orphaned secret", zap.String("path", r.Path))
-		if err := s.store.Delete(r.Path); err != nil {
-			log.Error("delete secret", zap.String("path", r.Path), zap.Error(err))
+		secret := orphans[i]
+		log.Info("deleting orphaned secret", zap.String("path", secret.Path))
+		if err := s.store.Delete(secret.Path); err != nil {
+			log.Error("delete secret", zap.String("path", secret.Path), zap.Error(err))
 		}
-		state.RemoveSecret(s.store.Type(), r)
+		state.RemoveSecret(s.store.Type(), secret)
 	}
 
 	return nil

--- a/sidecred.go
+++ b/sidecred.go
@@ -246,8 +246,9 @@ Loop:
 	}
 
 	for _, ps := range state.Providers {
-		for _, resource := range ps.Resources {
-			r := resource
+		// Reverse loop to handle index changes due to deleting items in the underlying array.
+		for i := len(ps.Resources) - 1; i >= 0; i-- {
+			r := ps.Resources[i]
 			if r.InUse && !r.Deposed && r.Expiration.After(time.Now()) {
 				continue
 			}
@@ -268,8 +269,9 @@ Loop:
 		}
 	}
 
-	for _, secret := range state.ListOrphanedSecrets(s.store.Type()) {
-		r := secret
+	orphans := state.ListOrphanedSecrets(s.store.Type())
+	for i := len(orphans) - 1; i >= 0; i-- {
+		r := orphans[i]
 		log.Info("deleting orphaned secret", zap.String("path", r.Path))
 		if err := s.store.Delete(r.Path); err != nil {
 			log.Error("delete secret", zap.String("path", r.Path), zap.Error(err))

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -157,6 +157,98 @@ func TestProcess(t *testing.T) {
 	}
 }
 
+// This test exists because looping over pointers as done when cleaning up expired/deposed
+// resources (and deposed secrets) can lead to surprising behaviours. The test below ensures
+// that things are working as intended.
+func TestProcessCleanup(t *testing.T) {
+	tests := []struct {
+		description          string
+		namespace            string
+		resources            []*sidecred.Resource
+		secrets              []*sidecred.Secret
+		expectedDestroyCalls int
+	}{
+		{
+			description: "sidecred works",
+			namespace:   "team-name",
+			resources: []*sidecred.Resource{
+				{
+					ID:         "r1",
+					Expiration: time.Now(),
+				},
+				{
+					ID:         "r2",
+					Expiration: time.Now(),
+				},
+				{
+					ID:         "r3",
+					Expiration: time.Now(),
+				},
+			},
+			secrets: []*sidecred.Secret{
+				{
+					ResourceID: "r1",
+					Path:       "path1",
+					Expiration: time.Now(),
+				},
+				{
+					ResourceID: "r1",
+					Path:       "path2",
+					Expiration: time.Now(),
+				},
+				{
+					ResourceID: "r2",
+					Path:       "path3",
+					Expiration: time.Now(),
+				},
+			},
+			expectedDestroyCalls: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			var (
+				store    = inprocess.New()
+				state    = sidecred.NewState()
+				provider = &fakeProvider{}
+				logger   = zaptest.NewLogger(t)
+			)
+
+			for _, r := range tc.resources {
+				state.AddResource(provider.Type(), r)
+			}
+
+			for _, s := range tc.secrets {
+				state.AddSecret(store.Type(), s)
+			}
+
+			s, err := sidecred.New([]sidecred.Provider{provider}, store, logger)
+			require.NoError(t, err)
+
+			err = s.Process(tc.namespace, []*sidecred.Request{}, state)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedDestroyCalls, provider.DestroyCallCount(), "destroy calls")
+
+			for _, p := range state.Providers {
+				if !assert.Equal(t, 0, len(p.Resources)) {
+					for _, s := range p.Resources {
+						assert.Nil(t, s)
+					}
+				}
+			}
+
+			for _, p := range state.Stores {
+				if !assert.Equal(t, 0, len(p.Secrets)) {
+					for _, s := range p.Secrets {
+						assert.Nil(t, s)
+					}
+				}
+			}
+		})
+	}
+}
+
 // Fake implementation of sidecred.Provider.
 type fakeProvider struct {
 	createCallCount  int

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -169,7 +169,7 @@ func TestProcessCleanup(t *testing.T) {
 		expectedDestroyCalls int
 	}{
 		{
-			description: "sidecred works",
+			description: "cleanup works",
 			namespace:   "team-name",
 			resources: []*sidecred.Resource{
 				{


### PR DESCRIPTION
See comment for the new test for a description of what this PR aims to fix:

```
--- FAIL: TestProcessCleanup (0.00s)
    --- FAIL: TestProcessCleanup/sidecred_works (0.00s)
##[error]        logger.go:130: 2020-01-31T13:49:48.908Z	INFO	starting sidecred	{"namespace": "team-name", "requests": 0}
##[error]        logger.go:130: 2020-01-31T13:49:48.908Z	INFO	destroying expired resource	{"type": "fake", "id": "r1"}
##[error]        logger.go:130: 2020-01-31T13:49:48.908Z	INFO	destroying expired resource	{"type": "fake", "id": "r3"}
##[error]        logger.go:130: 2020-01-31T13:49:48.908Z	INFO	destroying expired resource	{"type": "fake", "id": "r3"}
##[error]        logger.go:130: 2020-01-31T13:49:48.908Z	INFO	deleting orphaned secret	{"namespace": "team-name", "path": "path1"}
##[error]        logger.go:130: 2020-01-31T13:49:48.908Z	INFO	deleting orphaned secret	{"namespace": "team-name", "path": "path2"}
```

As you can see, the `r3` ID is deleted repeatedly, which leaves the `r2` ID remaining in state. This is likely because we are looping over pointers while modifying the underlying array. Tentative fix is to stop using pointers to the underlying struct for all these operations. E.g., it should be enough to pass around the `string` containing the IDs.