### PR TITLE
fix: encode the private key in PEM format

### DIFF
--- a/provider/github/github.go
+++ b/provider/github/github.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -158,7 +159,12 @@ func (p *provider) generateKeyPair() (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	privateKey := x509.MarshalPKCS1PrivateKey(key)
+
+	privateKey := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
 	pub, err := ssh.NewPublicKey(&key.PublicKey)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
> The private key must be in PEM format for consumption by the concourse
git-resource. Verified that this works in a pipeline using SSM as the store.

Replaces #10 since Github Actions does not trigger on forks.

edit: Apparently it does not need to replace the PR since it's the commit that is being tested.