### PR TITLE
fix: do not remove credentials that expired between expiry checks

### DIFF
--- a/sidecred.go
+++ b/sidecred.go
@@ -280,7 +280,7 @@ Loop:
 		// underlying array: https://stackoverflow.com/a/29006008
 		for i := len(ps.Resources) - 1; i >= 0; i-- {
 			resource := ps.Resources[i]
-			if resource.InUse && !resource.Deposed && resource.Expiration.After(time.Now()) {
+			if resource.InUse && !resource.Deposed {
 				continue
 			}
 			provider, ok := s.providers[ps.Type]


### PR DESCRIPTION
It is fairly likely that credentials will expire at roughly the same
time as the pertinent lambda is run to check their state. For example, a
lambda invoked by a CloudWatch rule every 5 minutes will likely be
running just about the same time as a referenced credential with a 40
minute expiry.

It is possible that the credential passes the `hasValidCredentials`
check, and then expires before the subsequent loop that checks to see if
the credential should be deleted for various reasons. One of those
checks is another expiry check. But that is unnecessary, since it has
just been run. So, we simply delete the second check, and leave the
expired credential in place. This "fixes" the issue, under the
assumption that the user sets the CloudWatch rule periodicity such that
it is _guaranteed_ to run at least one more time before true credential
expiry. That is, with a 10 minute CloudWatch rule periodicity, and a
credential that actually expires in 60 minutes, the user should set the
sidecred configured credential expiry to 50 min (minus epsilon). Thus if
we hit the race at that time, the rule would trigger the lambda to run
once more at 60 min (minus epsilon), and be guaranteed to find the
credential invalid, yet refresh it just as it would otherwise naturally
expire at the provider.

Fixes #22.