### PR TITLE
Add rotation window for credentials

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -56,6 +56,7 @@ func Setup(app *kingpin.Application, run runFunc, newAWSClient awsClientFactory,
 		ssmStoreKMSKeyID                   = app.Flag("ssm-store-kms-key-id", "KMS key to use for encrypting secrets stored in SSM Parameter store").String()
 		stateBackend                       = app.Flag("state-backend", "Backend to use for storing state").Required().String()
 		s3BackendBucket                    = app.Flag("s3-backend-bucket", "Bucket name to use for the S3 state backend").String()
+		credentialRotationWindow           = app.Flag("credential-rotation-window", "A window in time (duration) where sidecred should rotate credentials prior to their expiration").Default("10m").Duration()
 		debug                              = app.Flag("debug", "Enable debug logging").Bool()
 	)
 
@@ -139,7 +140,7 @@ func Setup(app *kingpin.Application, run runFunc, newAWSClient awsClientFactory,
 			logger.Fatal("unknown state backend", zap.String("backend", *stateBackend))
 		}
 
-		s, err := sidecred.New(providers, store, logger)
+		s, err := sidecred.New(providers, store, *credentialRotationWindow, logger)
 		if err != nil {
 			logger.Fatal("initialize sidecred", zap.Error(err))
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -56,7 +56,7 @@ func Setup(app *kingpin.Application, run runFunc, newAWSClient awsClientFactory,
 		ssmStoreKMSKeyID                   = app.Flag("ssm-store-kms-key-id", "KMS key to use for encrypting secrets stored in SSM Parameter store").String()
 		stateBackend                       = app.Flag("state-backend", "Backend to use for storing state").Required().String()
 		s3BackendBucket                    = app.Flag("s3-backend-bucket", "Bucket name to use for the S3 state backend").String()
-		credentialRotationWindow           = app.Flag("credential-rotation-window", "A window in time (duration) where sidecred should rotate credentials prior to their expiration").Default("10m").Duration()
+		rotationWindow                     = app.Flag("rotation-window", "A window in time (duration) where sidecred should rotate credentials prior to their expiration").Default("10m").Duration()
 		debug                              = app.Flag("debug", "Enable debug logging").Bool()
 	)
 
@@ -140,7 +140,7 @@ func Setup(app *kingpin.Application, run runFunc, newAWSClient awsClientFactory,
 			logger.Fatal("unknown state backend", zap.String("backend", *stateBackend))
 		}
 
-		s, err := sidecred.New(providers, store, *credentialRotationWindow, logger)
+		s, err := sidecred.New(providers, store, *rotationWindow, logger)
 		if err != nil {
 			logger.Fatal("initialize sidecred", zap.Error(err))
 		}

--- a/sidecred.go
+++ b/sidecred.go
@@ -51,7 +51,7 @@ func (r *Request) hasValidCredentials(resource *Resource, rotationWindow time.Du
 	if !isEqualConfig(r.Config, resource.Config) {
 		return false
 	}
-	if resource.Expiration.Before(time.Now().Add(rotationWindow)) {
+	if resource.Expiration.Add(-rotationWindow).Before(time.Now()) {
 		return false
 	}
 	return true

--- a/sidecred.go
+++ b/sidecred.go
@@ -26,24 +26,6 @@ type Request struct {
 	Config json.RawMessage `json:"config"`
 }
 
-// hasValidCredentials returns true if there are already valid credentials
-// for the request. This is determined by the last resource state.
-func (r *Request) hasValidCredentials(resource *Resource) bool {
-	if resource.Deposed {
-		return false
-	}
-	if r.Name != resource.ID {
-		return false
-	}
-	if !isEqualConfig(r.Config, resource.Config) {
-		return false
-	}
-	if resource.Expiration.Before(time.Now()) {
-		return false
-	}
-	return true
-}
-
 // UnmarshalConfig is a convenience method for unmarshalling the JSON config into
 // a config structure for a sidecred.Provider. When no config has been passed in
 // the request, no operation is performed by this function.
@@ -55,6 +37,24 @@ func (r *Request) UnmarshalConfig(target interface{}) error {
 		return fmt.Errorf("%s request: unmarshal: %s", r.Type, err)
 	}
 	return nil
+}
+
+// hasValidCredentials returns true if there are already valid credentials
+// for the request. This is determined by the last resource state.
+func (r *Request) hasValidCredentials(resource *Resource, rotationWindow time.Duration) bool {
+	if resource.Deposed {
+		return false
+	}
+	if r.Name != resource.ID {
+		return false
+	}
+	if !isEqualConfig(r.Config, resource.Config) {
+		return false
+	}
+	if resource.Expiration.Before(time.Now().Add(rotationWindow)) {
+		return false
+	}
+	return true
 }
 
 // isEqualConfig is a convenience function for unmarshalling the JSON config
@@ -206,11 +206,12 @@ func BuildSecretPath(pathTemplate, namespace, name string) (string, error) {
 }
 
 // New returns a new instance of sidecred.Sidecred with the desired configuration.
-func New(providers []Provider, store SecretStore, logger *zap.Logger) (*Sidecred, error) {
+func New(providers []Provider, store SecretStore, rotationWindow time.Duration, logger *zap.Logger) (*Sidecred, error) {
 	s := &Sidecred{
-		providers: make(map[ProviderType]Provider, len(providers)),
-		store:     store,
-		logger:    logger,
+		providers:      make(map[ProviderType]Provider, len(providers)),
+		store:          store,
+		rotationWindow: rotationWindow,
+		logger:         logger,
 	}
 	for _, p := range providers {
 		s.providers[p.Type()] = p
@@ -220,9 +221,10 @@ func New(providers []Provider, store SecretStore, logger *zap.Logger) (*Sidecred
 
 // Sidecred is the underlying datastructure for the service.
 type Sidecred struct {
-	providers map[ProviderType]Provider
-	store     SecretStore
-	logger    *zap.Logger
+	providers      map[ProviderType]Provider
+	store          SecretStore
+	rotationWindow time.Duration
+	logger         *zap.Logger
 }
 
 // Process a single sidecred.Request.
@@ -245,7 +247,7 @@ Loop:
 		log.Info("processing request", zap.String("name", r.Name))
 
 		for _, resource := range state.GetResourcesByID(p.Type(), r.Name) {
-			if r.hasValidCredentials(resource) {
+			if r.hasValidCredentials(resource, s.rotationWindow) {
 				log.Info("found existing credentials", zap.String("name", r.Name))
 				continue Loop
 			}


### PR DESCRIPTION
Part of #22 

This PR adds a "rotation window" where Sidecred will rotate credentials prior to their expiration. E.g. if one runs Sidecred in a Lambda every 5min, and stick with the default rotation window of 10min, credentials should have 2 shots at getting rotated before they actually expire.

Its a start, but I'm not sure its good enough 🤔 Another option might be to write a "last updated" to the state and use that to figure out what the rotation window needs to be in order to rotate credentials prior to their expiration - as suggested by @jhosteny.