### PR TITLE
Fix so release includes sidecred-lambda

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,8 @@ before:
 
 builds:
   - id: sidecred
-    main: ./cmd/sidecred
+    dir: ./cmd/sidecred
+    binary: sidecred
     ldflags: -buildid= -s -w
     env:
       - CGO_ENABLED=0
@@ -15,7 +16,8 @@ builds:
     goarch:
       - amd64
   - id: sidecred-lambda
-    main: ./cmd/sidecred-lambda
+    dir: ./cmd/sidecred-lambda
+    binary: sidecred-lambda
     ldflags: -buildid= -s -w
     env:
       - CGO_ENABLED=0
@@ -24,11 +26,14 @@ builds:
     goarch:
       - amd64
 
+archives:
+  - format: binary
+    builds:
+      - sidecred
+      - sidecred-lambda
+
 checksum:
   name_template: 'checksums.txt'
-
-archives:
-- format: binary
 
 release:
   prerelease: auto


### PR DESCRIPTION
This fixes the fact that `sidecred-lambda` was never included in the release because the binary name ended up being duplicated. Apparently building two binaries requires:

- Setting `binary` to solve the above naming conflict (defaults to project name, which defaults to `sidecred`/root directory).
- `id` defaults to `sidecred` (same as above), but needs to be unique per entry in `builds`.
- We also need to specify `dir` or `main` because `main.go` is not in root directory.

A bit more verbose than I'd like, oh well 🤷‍♂️ 