### PR TITLE
Automate upload of sidecred lambda

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,15 @@ jobs:
       with: { version: latest, args: release --rm-dist }
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Configure AWS
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-1
+    - name: Upload Lambda
+      run: |
+        zip -mj "${VERSION}.zip" dist/sidecred-lambda_linux_amd64/sidecred-lambda
+        aws s3 cp "${VERSION}.zip" "s3://telia-oss/sidecred-lambda/${VERSION}.zip"
+      env:
+        VERSION: ${{ github.ref }}


### PR DESCRIPTION
This automatically uploads a zipped version of the sidecred lambda to s3, which is then replicated to buckets in each region so that it can be easily deployed.