### PR TITLE
Fix tag version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,9 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-1
-    - name: Get version
-      id: version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
     - name: Upload Lambda
       run: |
         zip -mj "${VERSION}.zip" dist/sidecred-lambda_linux_amd64/sidecred-lambda
         aws s3 cp "${VERSION}.zip" "s3://telia-oss/sidecred-lambda/${VERSION}.zip"
       env:
-        VERSION: ${{ steps.version.outputs.VERSION }}
+        VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,12 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-1
+    - name: Get version
+      id: version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
     - name: Upload Lambda
       run: |
         zip -mj "${VERSION}.zip" dist/sidecred-lambda_linux_amd64/sidecred-lambda
         aws s3 cp "${VERSION}.zip" "s3://telia-oss/sidecred-lambda/${VERSION}.zip"
       env:
-        VERSION: ${{ github.ref }}
+        VERSION: ${{ steps.version.outputs.VERSION }}


### PR DESCRIPTION
Current release action errors with:
```
zip I/O error: No such file or directory
zip error: Could not create output file (refs/tags/v0.2.2.zip)
```

What we are after here is `v0.2.2.zip` not the actual ref 😅 