### PR TITLE
Clean up goreleaser and release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,9 @@ jobs:
         aws-region: eu-west-1
     - name: Get version
       id: version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
     - name: Upload Lambda
       run: |
-        zip -mj "${VERSION}.zip" dist/sidecred-lambda_linux_amd64/sidecred-lambda
-        aws s3 cp "${VERSION}.zip" "s3://telia-oss/sidecred-lambda/${VERSION}.zip" --acl public-read
+        aws s3 cp "dist/sidecred-lambda-${VERSION}-linux-amd64.zip" "s3://telia-oss/sidecred-lambda/v${VERSION}.zip" --acl public-read
       env:
         VERSION: ${{ steps.version.outputs.VERSION }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,10 +3,8 @@ before:
     - go mod download
 
 builds:
-  - id: sidecred
-    dir: ./cmd/sidecred
-    binary: sidecred
-    ldflags: -buildid= -s -w
+- main: ./cmd/sidecred/main.go
+  <<: &config
     env:
       - CGO_ENABLED=0
     goos:
@@ -15,25 +13,39 @@ builds:
       - windows
     goarch:
       - amd64
-  - id: sidecred-lambda
-    dir: ./cmd/sidecred-lambda
-    binary: sidecred-lambda
-    ldflags: -buildid= -s -w
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-    goarch:
-      - amd64
+    ldflags: -buildid="" -s -w
+
+- main: ./cmd/sidecred-lambda/main.go
+  <<: *config
+  id: sidecred-lambda
+  binary: sidecred-lambda
+  goos:
+    - linux
 
 archives:
-  - format: binary
+  - name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+  - name_template: "{{ .ProjectName }}-lambda-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    id: sidecred-lambda
     builds:
-      - sidecred
       - sidecred-lambda
+    format: zip
 
 checksum:
   name_template: 'checksums.txt'
 
+snapshot:
+  name_template: "{{ .Version }}-{{ .ShortCommit }}"
+
 release:
   prerelease: auto
+
+blobs:
+  - provider: s3
+    ids:
+      - sidecred-lambda
+    region: eu-west-1
+    bucket: telia-oss
+    folder: "{{ .ProjectName }}-lambda/{{ .Version }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,11 +41,3 @@ snapshot:
 
 release:
   prerelease: auto
-
-blobs:
-  - provider: s3
-    ids:
-      - sidecred-lambda
-    region: eu-west-1
-    bucket: telia-oss
-    folder: "{{ .ProjectName }}-lambda/{{ .Version }}"


### PR DESCRIPTION
Clean up artifact names, and archive binaries before uploading to Github. Plan was to use goreleaser to upload the S3 artifact also, but unfortunately goreleaser does not support setting the ACL on S3 objects.