### PR TITLE
Add support for scoping github access tokens (repos and permissions)

### DIFF
--- a/cmd/sidecred/testdata/config.yml
+++ b/cmd/sidecred/testdata/config.yml
@@ -7,6 +7,10 @@
   name: itsdalmo-access-token
   config:
     owner: itsdalmo
+    repositories:
+      - dotfiles
+    permissions:
+      content: read
 - type: github:deploy-key
   name: dotfiles-deploy-key
   config:


### PR DESCRIPTION
Followup to #38 - this PR allows for configuring the permissions and repositories for an access token request. This change should not affect the default behaviour.