### PR TITLE
Add support for multiple stores

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,9 +6,15 @@ import (
 
 // Config represents the user-defined configuration that should be passed to the sidecred.Sidecred.Process method.
 type Config struct {
-	Version   int        `json:"version"`
-	Namespace string     `json:"namespace"`
-	Requests  []*Request `json:"requests"`
+	Version   int    `json:"version"`
+	Namespace string `json:"namespace"`
+	Stores    []struct {
+		Type StoreType `json:"type"`
+	}
+	Requests []struct {
+		Store string     `json:"store"`
+		Creds []*Request `json:"creds"`
+	}
 }
 
 // Validate the configuration.
@@ -19,17 +25,41 @@ func (c *Config) Validate() error {
 	if c.Namespace == "" {
 		return fmt.Errorf("%q must be defined", "namespace")
 	}
-	requests := make(map[string]struct{}, len(c.Requests))
-	for i, r := range c.Requests {
-		switch r.Type {
-		case AWSSTS, GithubAccessToken, GithubDeployKey, ArtifactoryAccessToken, Randomized:
+	if len(c.Stores) == 0 {
+		return fmt.Errorf("%q must be defined", "stores")
+	}
+	stores := make(map[string]struct{}, len(c.Stores))
+	for i, s := range c.Stores {
+		switch s.Type {
+		case Inprocess, SSM, SecretsManager, GithubSecrets:
 		default:
-			return fmt.Errorf("requests[%d]: unknown type %q", i, string(r.Type))
+			return fmt.Errorf("stores[%d]: unknown type %q", i, string(s.Type))
 		}
-		if _, found := requests[r.Name]; found {
-			return fmt.Errorf("requests[%d]: duplicate request %q", i, r.Name)
+		if _, found := stores[string(s.Type)]; found {
+			return fmt.Errorf("stores[%d]: duplicate store %q", i, string(s.Type))
 		}
-		requests[r.Name] = struct{}{}
+		stores[string(s.Type)] = struct{}{}
+	}
+
+	type requestsKey struct{ store, name string }
+	requests := make(map[requestsKey]struct{}, len(c.Requests))
+
+	for i, request := range c.Requests {
+		if _, found := stores[request.Store]; !found {
+			return fmt.Errorf("requests[%d]: undefined store %q", i, request.Store)
+		}
+		for ii, r := range request.Creds {
+			switch r.Type {
+			case AWSSTS, GithubAccessToken, GithubDeployKey, ArtifactoryAccessToken, Randomized:
+			default:
+				return fmt.Errorf("requests[%d]: creds[%d]: unknown type %q", i, ii, string(r.Type))
+			}
+			key := requestsKey{store: request.Store, name: r.Name}
+			if _, found := requests[key]; found {
+				return fmt.Errorf("requests[%d]: creds[%d]: duplicated request %+v", i, ii, key)
+			}
+			requests[key] = struct{}{}
+		}
 	}
 	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -24,12 +24,17 @@ func TestConfig(t *testing.T) {
 version: 1
 namespace: cloudops
 
+stores:
+  - type: secretsmanager
+
 requests:
-  - type: aws:sts
-    name: open-source-dev-read-only
-    config:
-      role_arn: arn:aws:iam::role/role-name
-      duration: 900
+  - store: secretsmanager
+    creds:
+    - type: aws:sts
+      name: open-source-dev-read-only
+      config:
+        role_arn: arn:aws:iam::role/role-name
+        duration: 900
             `),
 			expected: "",
 		},
@@ -40,16 +45,22 @@ requests:
 version: 1
 namespace: cloudops
 
+stores:
+  - type: secretsmanager
+  - type: inprocess
+
 requests:
-  - type: aws:sts
-    name: open-source-dev-read-only
-    config:
-      role_arn: arn:aws:iam::role/role-name
-      duration: 900
-  - type: aws:sts
-    name: open-source-dev-read-only
+  - store: secretsmanager
+    creds:
+    - type: aws:sts
+      name: open-source-dev-read-only
+      config:
+        role_arn: arn:aws:iam::role/role-name
+        duration: 900
+    - type: aws:sts
+      name: open-source-dev-read-only
             `),
-			expected: `requests[1]: duplicate request "open-source-dev-read-only"`,
+			expected: `requests[0]: creds[1]: duplicated request {store:secretsmanager name:open-source-dev-read-only}`,
 		},
 	}
 


### PR DESCRIPTION
This PR adds support for using multiple secret stores at a time, the stores have to be enabled in the command line AND it has to be enabled and referenced in the config (`sidecred.Config`). The next step is to add support for having multiple stores of the same type, but with differing configs.