### PR TITLE
Rename Request to CredentialRequest for clarity

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,8 +12,8 @@ type Config struct {
 		Type StoreType `json:"type"`
 	}
 	Requests []struct {
-		Store string     `json:"store"`
-		Creds []*Request `json:"creds"`
+		Store string               `json:"store"`
+		Creds []*CredentialRequest `json:"creds"`
 	}
 }
 

--- a/provider/artifactory/artifactory.go
+++ b/provider/artifactory/artifactory.go
@@ -117,7 +117,7 @@ func (p *provider) Type() sidecred.ProviderType {
 }
 
 // Provide implements sidecred.Provider.
-func (p *provider) Create(request *sidecred.Request) ([]*sidecred.Credential, *sidecred.Metadata, error) {
+func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
 	var c RequestConfig
 	if err := request.UnmarshalConfig(&c); err != nil {
 		return nil, nil, err

--- a/provider/artifactory/artifactory_test.go
+++ b/provider/artifactory/artifactory_test.go
@@ -29,14 +29,14 @@ func TestArtifactoryProvider(t *testing.T) {
 		description             string
 		sessionDuration         time.Duration
 		expectedSessionDuration int64
-		request                 *sidecred.Request
+		request                 *sidecred.CredentialRequest
 		artifactoryAPIOutput    *services.CreateTokenResponseData
 	}{
 		{
 			description:             "artifactory provider works",
 			sessionDuration:         30 * time.Minute,
 			expectedSessionDuration: 1800,
-			request: &sidecred.Request{
+			request: &sidecred.CredentialRequest{
 				Type:   sidecred.ArtifactoryAccessToken,
 				Name:   "request-name",
 				Config: []byte(`{"user": "some-user", "group": "some-artifactory-group"}`),
@@ -46,7 +46,7 @@ func TestArtifactoryProvider(t *testing.T) {
 			description:             "request duration overrides default",
 			sessionDuration:         30 * time.Minute,
 			expectedSessionDuration: 60,
-			request: &sidecred.Request{
+			request: &sidecred.CredentialRequest{
 				Type:   sidecred.AWSSTS,
 				Name:   "request-name",
 				Config: []byte(`{"user": "some-user", "group": "some-artifactory-group", "duration": 60}`),

--- a/provider/github/github.go
+++ b/provider/github/github.go
@@ -86,7 +86,7 @@ func (p *provider) Type() sidecred.ProviderType {
 }
 
 // Create implements sidecred.Provider.
-func (p *provider) Create(request *sidecred.Request) ([]*sidecred.Credential, *sidecred.Metadata, error) {
+func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
 	switch request.Type {
 	case sidecred.GithubDeployKey:
 		return p.createDeployKey(request)
@@ -96,7 +96,7 @@ func (p *provider) Create(request *sidecred.Request) ([]*sidecred.Credential, *s
 	return nil, nil, fmt.Errorf("invalid request: %s", request.Type)
 }
 
-func (p *provider) createAccessToken(request *sidecred.Request) ([]*sidecred.Credential, *sidecred.Metadata, error) {
+func (p *provider) createAccessToken(request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
 	var c AccessTokenRequestConfig
 	if err := request.UnmarshalConfig(&c); err != nil {
 		return nil, nil, err
@@ -117,7 +117,7 @@ func (p *provider) createAccessToken(request *sidecred.Request) ([]*sidecred.Cre
 	}}, nil, nil
 }
 
-func (p *provider) createDeployKey(request *sidecred.Request) ([]*sidecred.Credential, *sidecred.Metadata, error) {
+func (p *provider) createDeployKey(request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
 	var c DeployKeyRequestConfig
 	if err := request.UnmarshalConfig(&c); err != nil {
 		return nil, nil, err

--- a/provider/github/github_test.go
+++ b/provider/github/github_test.go
@@ -25,13 +25,13 @@ func TestGithubProvider(t *testing.T) {
 	)
 	tests := []struct {
 		description      string
-		request          *sidecred.Request
+		request          *sidecred.CredentialRequest
 		expected         []*sidecred.Credential
 		expectedMetadata *sidecred.Metadata
 	}{
 		{
 			description: "Github provider works for deploy keys",
-			request: &sidecred.Request{
+			request: &sidecred.CredentialRequest{
 				Type:   sidecred.GithubDeployKey,
 				Name:   "request-name",
 				Config: []byte(`{"owner":"request-owner","repository":"request-repository","title":"request-title","read_only":true}`),
@@ -44,7 +44,7 @@ func TestGithubProvider(t *testing.T) {
 		},
 		{
 			description: "Github provider works for access tokens",
-			request: &sidecred.Request{
+			request: &sidecred.CredentialRequest{
 				Type:   sidecred.GithubAccessToken,
 				Name:   "request-name",
 				Config: []byte(`{"owner":"request-owner"}`),

--- a/provider/random/random.go
+++ b/provider/random/random.go
@@ -47,7 +47,7 @@ func (p *provider) Type() sidecred.ProviderType {
 }
 
 // Provide implements sidecred.Provider.
-func (p *provider) Create(request *sidecred.Request) ([]*sidecred.Credential, *sidecred.Metadata, error) {
+func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
 	var c RequestConfig
 	if err := request.UnmarshalConfig(&c); err != nil {
 		return nil, nil, err

--- a/provider/random/random_test.go
+++ b/provider/random/random_test.go
@@ -14,13 +14,13 @@ func TestRandomProvider(t *testing.T) {
 	tests := []struct {
 		description string
 		seed        int64
-		request     *sidecred.Request
+		request     *sidecred.CredentialRequest
 		expected    []*sidecred.Credential
 	}{
 		{
 			description: "random provider works",
 			seed:        1,
-			request: &sidecred.Request{
+			request: &sidecred.CredentialRequest{
 				Type: sidecred.Randomized,
 				Name: "request-name",
 			},
@@ -33,7 +33,7 @@ func TestRandomProvider(t *testing.T) {
 		{
 			description: "we can set the length of the random string",
 			seed:        1,
-			request: &sidecred.Request{
+			request: &sidecred.CredentialRequest{
 				Type:   sidecred.Randomized,
 				Name:   "request-name",
 				Config: []byte(`{"length":5}`),
@@ -47,7 +47,7 @@ func TestRandomProvider(t *testing.T) {
 		{
 			description: "we can control the seed",
 			seed:        2,
-			request: &sidecred.Request{
+			request: &sidecred.CredentialRequest{
 				Type:   sidecred.Randomized,
 				Name:   "request-name",
 				Config: []byte(`{"length":5}`),

--- a/provider/sts/sts.go
+++ b/provider/sts/sts.go
@@ -64,7 +64,7 @@ func (p *provider) Type() sidecred.ProviderType {
 }
 
 // Provide implements sidecred.Provider.
-func (p *provider) Create(request *sidecred.Request) ([]*sidecred.Credential, *sidecred.Metadata, error) {
+func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
 	var c RequestConfig
 	if err := request.UnmarshalConfig(&c); err != nil {
 		return nil, nil, err

--- a/provider/sts/sts_test.go
+++ b/provider/sts/sts_test.go
@@ -37,7 +37,7 @@ func TestSTSProvider(t *testing.T) {
 		externalID              string
 		sessionDuration         time.Duration
 		expectedSessionDuration int64
-		request                 *sidecred.Request
+		request                 *sidecred.CredentialRequest
 		stsAPIOutput            *sts.AssumeRoleOutput
 	}{
 		{
@@ -45,7 +45,7 @@ func TestSTSProvider(t *testing.T) {
 			externalID:              "externalID",
 			sessionDuration:         30 * time.Minute,
 			expectedSessionDuration: 1800,
-			request: &sidecred.Request{
+			request: &sidecred.CredentialRequest{
 				Type:   sidecred.AWSSTS,
 				Name:   "request-name",
 				Config: []byte(`{"role_arn": "request-role-arn"}`),
@@ -56,7 +56,7 @@ func TestSTSProvider(t *testing.T) {
 			externalID:              "externalID",
 			sessionDuration:         30 * time.Minute,
 			expectedSessionDuration: 60,
-			request: &sidecred.Request{
+			request: &sidecred.CredentialRequest{
 				Type:   sidecred.AWSSTS,
 				Name:   "request-name",
 				Config: []byte(`{"role_arn": "request-role-arn", "duration":60}`),

--- a/sidecred.go
+++ b/sidecred.go
@@ -11,8 +11,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// Request is the root datastructure used to request credentials in Sidecred.
-type Request struct {
+// CredentialRequest is the root datastructure used to request credentials in Sidecred.
+type CredentialRequest struct {
 	// Type identifies the type of credential (and provider) for a request.
 	Type CredentialType `json:"type"`
 
@@ -29,7 +29,7 @@ type Request struct {
 // UnmarshalConfig is a convenience method for unmarshalling the JSON config into
 // a config structure for a sidecred.Provider. When no config has been passed in
 // the request, no operation is performed by this function.
-func (r *Request) UnmarshalConfig(target interface{}) error {
+func (r *CredentialRequest) UnmarshalConfig(target interface{}) error {
 	if len(r.Config) == 0 {
 		return nil
 	}
@@ -41,7 +41,7 @@ func (r *Request) UnmarshalConfig(target interface{}) error {
 
 // hasValidCredentials returns true if there are already valid credentials
 // for the request. This is determined by the last resource state.
-func (r *Request) hasValidCredentials(resource *Resource, rotationWindow time.Duration) bool {
+func (r *CredentialRequest) hasValidCredentials(resource *Resource, rotationWindow time.Duration) bool {
 	if resource.Deposed {
 		return false
 	}
@@ -129,7 +129,7 @@ type Provider interface {
 	// Create the requested credentials. Any sidecred.Resource
 	// returned will be stored in state and used to determine
 	// when credentials need to be rotated.
-	Create(request *Request) ([]*Credential, *Metadata, error)
+	Create(request *CredentialRequest) ([]*Credential, *Metadata, error)
 
 	// Destroy the specified resource. This is scheduled if
 	// a resource in the state has expired. For providers that

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -23,7 +23,7 @@ func TestProcess(t *testing.T) {
 		description          string
 		namespace            string
 		resources            []*sidecred.Resource
-		requests             []*sidecred.Request
+		requests             []*sidecred.CredentialRequest
 		expectedSecrets      map[string]string
 		expectedResources    []*sidecred.Resource
 		expectedCreateCalls  int
@@ -32,7 +32,7 @@ func TestProcess(t *testing.T) {
 		{
 			description: "sidecred works",
 			namespace:   "team-name",
-			requests: []*sidecred.Request{{
+			requests: []*sidecred.CredentialRequest{{
 				Type: testCredentialType,
 				Name: testStateID,
 			}},
@@ -53,7 +53,7 @@ func TestProcess(t *testing.T) {
 				ID:         testStateID,
 				Expiration: testTime,
 			}},
-			requests: []*sidecred.Request{{
+			requests: []*sidecred.CredentialRequest{{
 				Type: testCredentialType,
 				Name: testStateID,
 			}},
@@ -72,7 +72,7 @@ func TestProcess(t *testing.T) {
 				ID:         testStateID,
 				Expiration: time.Now().Add(3 * time.Minute),
 			}},
-			requests: []*sidecred.Request{{
+			requests: []*sidecred.CredentialRequest{{
 				Type: testCredentialType,
 				Name: testStateID,
 			}},
@@ -91,7 +91,7 @@ func TestProcess(t *testing.T) {
 				ID:         testStateID,
 				Expiration: time.Now(),
 			}},
-			requests: []*sidecred.Request{{
+			requests: []*sidecred.CredentialRequest{{
 				Type: testCredentialType,
 				Name: testStateID,
 			}},
@@ -110,7 +110,7 @@ func TestProcess(t *testing.T) {
 				ID:         "other.state.id",
 				Expiration: testTime,
 			}},
-			requests:             []*sidecred.Request{},
+			requests:             []*sidecred.CredentialRequest{},
 			expectedResources:    []*sidecred.Resource{},
 			expectedDestroyCalls: 1,
 		},
@@ -123,7 +123,7 @@ func TestProcess(t *testing.T) {
 			description: "does nothing if there are no providers for the request",
 			namespace:   "team-name",
 			resources:   []*sidecred.Resource{},
-			requests: []*sidecred.Request{{
+			requests: []*sidecred.CredentialRequest{{
 				Type: sidecred.AWSSTS,
 				Name: testStateID,
 			}},
@@ -235,7 +235,7 @@ func TestProcessCleanup(t *testing.T) {
 			s, err := sidecred.New([]sidecred.Provider{provider}, []sidecred.SecretStore{store}, 10*time.Minute, logger)
 			require.NoError(t, err)
 
-			err = s.Process(newConfig(tc.namespace, []*sidecred.Request{}), state)
+			err = s.Process(newConfig(tc.namespace, []*sidecred.CredentialRequest{}), state)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedDestroyCalls, provider.DestroyCallCount(), "destroy calls")
 
@@ -258,10 +258,10 @@ func TestProcessCleanup(t *testing.T) {
 	}
 }
 
-func newConfig(namespace string, requests []*sidecred.Request) *sidecred.Config {
+func newConfig(namespace string, requests []*sidecred.CredentialRequest) *sidecred.Config {
 	rs := []struct {
-		Store string              `json:"store"`
-		Creds []*sidecred.Request `json:"creds"`
+		Store string                        `json:"store"`
+		Creds []*sidecred.CredentialRequest `json:"creds"`
 	}{
 		{
 			Store: string(sidecred.Inprocess),
@@ -293,7 +293,7 @@ func (f *fakeProvider) Type() sidecred.ProviderType {
 	return sidecred.ProviderType("fake")
 }
 
-func (f *fakeProvider) Create(r *sidecred.Request) ([]*sidecred.Credential, *sidecred.Metadata, error) {
+func (f *fakeProvider) Create(r *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
 	f.createCallCount++
 	return []*sidecred.Credential{{
 			Name:       "fake-credential",

--- a/state.go
+++ b/state.go
@@ -42,7 +42,7 @@ func (s *State) getProviderState(t ProviderType) (*providerState, bool) {
 }
 
 // newResource returns a new sidecred.Resource.
-func newResource(request *Request, expiration time.Time, metadata *Metadata) *Resource {
+func newResource(request *CredentialRequest, expiration time.Time, metadata *Metadata) *Resource {
 	return &Resource{
 		ID:         request.Name,
 		Config:     request.Config,


### PR DESCRIPTION
Since `sidecred.Config` has a `requests:` section that has a different format than the current `sidecred.Request` I suggest renaming the struct to `sidecred.CredentialRequest` to avoid confusing the two. I'll base future PRs on this change.