### PR TITLE
User configured stores

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -67,6 +67,32 @@ requests:
 			expectedCountPerRequest: []int{1},
 		},
 		{
+			description: "supports named stores",
+			config: strings.TrimSpace(`
+---
+version: 1
+namespace: cloudops
+
+stores:
+  - type: secretsmanager
+  - type: secretsmanager
+    name: concourse
+
+requests:
+  - store: concourse
+    creds:
+    - type: aws:sts
+      list:
+      - name: open-source-dev-read-only
+        config:
+          role_arn: arn:aws:iam::role/role-name
+          duration: 900
+            `),
+			expected:                "",
+			expectedRequestCount:    1,
+			expectedCountPerRequest: []int{1},
+		},
+		{
 			description: "errors on duplicate requests",
 			config: strings.TrimSpace(`
 ---

--- a/provider/artifactory/artifactory_e2e_test.go
+++ b/provider/artifactory/artifactory_e2e_test.go
@@ -1,4 +1,4 @@
-// +build e2e
+// +build artifactorye2e
 
 package artifactory_test
 
@@ -57,7 +57,7 @@ func TestArtifactoryProviderE2E(t *testing.T) {
 				provider.WithSessionDuration(15*time.Minute),
 			)
 
-			_, _, err = p.Create(&sidecred.Request{
+			_, _, err = p.Create(&sidecred.CredentialRequest{
 				Type:   sidecred.ArtifactoryAccessToken,
 				Name:   "request-name",
 				Config: []byte(fmt.Sprintf(`{"user":"%s", "group":"%s"}`, artifactoryUser, artifactoryGroup)),

--- a/provider/artifactory/artifactory_e2e_test.go
+++ b/provider/artifactory/artifactory_e2e_test.go
@@ -1,4 +1,4 @@
-// +build artifactorye2e
+// +build e2e
 
 package artifactory_test
 

--- a/provider/github/github_e2e_test.go
+++ b/provider/github/github_e2e_test.go
@@ -47,7 +47,7 @@ func TestGithubProviderE2E(t *testing.T) {
 			client, err := githubapp.NewClient(integrationID, privateKey)
 			require.NoError(t, err)
 
-			request := &sidecred.Request{
+			request := &sidecred.CredentialRequest{
 				Type: sidecred.GithubDeployKey,
 				Name: "itsdalmo-dotfiles-deploy-key",
 				Config: []byte(

--- a/provider/sts/sts_e2e_test.go
+++ b/provider/sts/sts_e2e_test.go
@@ -46,7 +46,7 @@ func TestSTSProviderE2E(t *testing.T) {
 				provider.WithExternalID("sidecred-e2e-test"),
 			)
 
-			_, _, err = p.Create(&sidecred.Request{
+			_, _, err = p.Create(&sidecred.CredentialRequest{
 				Type:   sidecred.AWSSTS,
 				Name:   "request-name",
 				Config: []byte(fmt.Sprintf(`{"role_arn":"%s"}`, roleARN)),

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -157,7 +157,7 @@ func TestProcess(t *testing.T) {
 			}
 
 			for k, v := range tc.expectedSecrets {
-				value, found, err := store.Read(k)
+				value, found, err := store.Read(k, sidecred.NoConfig)
 				assert.NoError(t, err)
 				assert.True(t, found, "secret exists")
 				assert.Equal(t, v, value)
@@ -229,7 +229,7 @@ func TestProcessCleanup(t *testing.T) {
 			}
 
 			for _, s := range tc.secrets {
-				state.AddSecret(store.Type(), s)
+				state.AddSecret(&sidecred.StoreConfig{Type: store.Type()}, s)
 			}
 
 			s, err := sidecred.New([]sidecred.Provider{provider}, []sidecred.SecretStore{store}, 10*time.Minute, logger)
@@ -265,17 +265,12 @@ func newConfig(namespace string, requests []*sidecred.CredentialRequest) *sidecr
 			CredentialRequest: r,
 		})
 	}
-	ss := []struct {
-		Type sidecred.StoreType `json:"type"`
-	}{
-		{
-			Type: sidecred.Inprocess,
-		},
-	}
 	return &sidecred.Config{
 		Version:   1,
 		Namespace: namespace,
-		Stores:    ss,
+		Stores: []*sidecred.StoreConfig{{
+			Type: sidecred.Inprocess,
+		}},
 		Requests: []*sidecred.RequestConfig{{
 			Store: string(sidecred.Inprocess),
 			Creds: re,

--- a/state_test.go
+++ b/state_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/telia-oss/sidecred"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/telia-oss/sidecred"
 )
 
 var (
@@ -27,10 +28,10 @@ func TestState(t *testing.T) {
 			description: "state works",
 			stateID:     testStateID,
 			expectedJSON: strings.TrimSpace(`
-{"providers":[{"type":"random","resources":[{"id":"fake.state.id","expiration":"2020-01-30T12:00:00Z","deposed":false}]}],"stores":[{"type":"inprocess","secrets":[{"resource_id":"fake.state.id","path":"fake.store.path","expiration":"2020-01-30T12:00:00Z"}]}]}
+{"providers":[{"type":"random","resources":[{"id":"fake.state.id","expiration":"2020-01-30T12:00:00Z","deposed":false}]}],"stores":[{"type":"inprocess","name":"","secrets":[{"resource_id":"fake.state.id","path":"fake.store.path","expiration":"2020-01-30T12:00:00Z"}]}]}
 `),
 			expectedFinalJSON: strings.TrimSpace(`
-{"providers":[{"type":"random","resources":[]}],"stores":[{"type":"inprocess","secrets":[]}]}
+{"providers":[{"type":"random","resources":[]}],"stores":[{"type":"inprocess","name":"","secrets":[]}]}
 `),
 		},
 	}
@@ -43,7 +44,8 @@ func TestState(t *testing.T) {
 				ID:         tc.stateID,
 				Expiration: fixedTestTime,
 			})
-			state.AddSecret(sidecred.Inprocess, &sidecred.Secret{
+			storeConfig := &sidecred.StoreConfig{Type: sidecred.Inprocess}
+			state.AddSecret(storeConfig, &sidecred.Secret{
 				ResourceID: tc.stateID,
 				Path:       "fake.store.path",
 				Expiration: fixedTestTime,
@@ -54,7 +56,7 @@ func TestState(t *testing.T) {
 			assert.Equal(t, tc.expectedJSON, string(outputJSON))
 
 			state.RemoveResource(sidecred.Random, &sidecred.Resource{ID: tc.stateID})
-			state.RemoveSecret(sidecred.Inprocess, &sidecred.Secret{Path: "fake.store.path"})
+			state.RemoveSecret(storeConfig, &sidecred.Secret{Path: "fake.store.path"})
 
 			finalOutputJSON, err := json.Marshal(state)
 			require.NoError(t, err)

--- a/store/github/github_e2e_test.go
+++ b/store/github/github_e2e_test.go
@@ -3,6 +3,7 @@
 package github_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -58,24 +59,24 @@ func TestGithubStoreE2E(t *testing.T) {
 
 			store := secretstore.New(
 				githubapp.New(client),
-				targetOrganisation,
-				targetRepository,
 				secretstore.WithSecretTemplate(tc.pathTemplate),
 			)
+
+			config := []byte(fmt.Sprintf(`{"repository":"%s/%s"}`, targetOrganisation, targetRepository))
 
 			path, err := store.Write(namespace, &sidecred.Credential{
 				Name:  secretName,
 				Value: secretValue,
-			})
+			}, config)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedPath, path)
 
-			value, found, err := store.Read(path)
+			value, found, err := store.Read(path, config)
 			assert.NoError(t, err, "read secret")
 			assert.True(t, found, "found secret")
 			assert.Equal(t, tc.expectedPath, value)
 
-			if err := store.Delete(path); err != nil {
+			if err := store.Delete(path, config); err != nil {
 				t.Errorf("delete secret (%s): %s", path, err)
 			}
 		})

--- a/store/secretsmanager/secretsmanager_e2e_test.go
+++ b/store/secretsmanager/secretsmanager_e2e_test.go
@@ -46,22 +46,22 @@ func TestSecretsManagerStoreE2E(t *testing.T) {
 
 			store := secretstore.New(
 				secretstore.NewClient(sess),
-				secretstore.WithPathTemplate(tc.pathTemplate),
+				secretstore.WithSecretTemplate(tc.pathTemplate),
 			)
 
 			path, err := store.Write(namespace, &sidecred.Credential{
 				Name:  secretName,
 				Value: secretValue,
-			})
+			}, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedPath, path)
 
-			value, found, err := store.Read(path)
+			value, found, err := store.Read(path, nil)
 			assert.NoError(t, err, "read secret")
 			assert.True(t, found, "found secret")
 			assert.Equal(t, secretValue, value)
 
-			if err := store.Delete(path); err != nil {
+			if err := store.Delete(path, nil); err != nil {
 				t.Errorf("delete secret (%s): %s", path, err)
 			}
 		})

--- a/store/ssm/ssm_e2e_test.go
+++ b/store/ssm/ssm_e2e_test.go
@@ -46,22 +46,22 @@ func TestSecretsManagerStoreE2E(t *testing.T) {
 
 			store := secretstore.New(
 				secretstore.NewClient(sess),
-				secretstore.WithPathTemplate(tc.pathTemplate),
+				secretstore.WithSecretTemplate(tc.pathTemplate),
 			)
 
 			path, err := store.Write(namespace, &sidecred.Credential{
 				Name:  secretName,
 				Value: secretValue,
-			})
+			}, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedPath, path)
 
-			value, found, err := store.Read(path)
+			value, found, err := store.Read(path, nil)
 			assert.NoError(t, err, "read secret")
 			assert.True(t, found, "found secret")
 			assert.Equal(t, secretValue, value)
 
-			if err := store.Delete(path); err != nil {
+			if err := store.Delete(path, nil); err != nil {
 				t.Errorf("delete secret (%s): %s", path, err)
 			}
 		})


### PR DESCRIPTION
This pull request adds support for user configured stores. E.g.:

```
stores:
  - type: secretsmanager
    name: concourse
    config:
      secret_template: "/concourse/{{ .Namespace }}/{{ .Name }}"
```

In this case, the specified `secret_template` would be used instead of the template passed from the command line when writing to this store. In cases where no config is specified, `sidecred` defaults to what was passed to `SIDECRED_SECRETS_MANAGER_STORE_SECRET_TEMPLATE` in the environment.

In order for the above to work I also had to change:
- How stores are saved to `state`: it now needs to include the config so we can know whether it has changed.
- Since Github secrets do not have a concept of "paths" I opted to rename the "pathTemplate" to "secretTemplate" everywhere so that it would correspond to the `secret_template` accepted in the store configs.
- I took the liberty of moving some code around to make it reusable (e.g. the `UnmarshalConfig` function).

I.e. it is a bit harder to review this PR, and it is riddled with breaking changes 😅 