### PR TITLE
Added Abililty to Override Default Rotation Window for Credentials Requests

### DIFF
--- a/sidecred.go
+++ b/sidecred.go
@@ -26,7 +26,7 @@ type CredentialRequest struct {
 	// for possibly longer running authentications or processes.
 	//
 	// Needs to be a int because JSON unmarshalling does not support Duration
-	Rotation int `json:"rotation"`
+	RotationWindow int `json:"rotation_window"`
 
 	// Config holds the specific configuration for the requested credential
 	// type, and must be deserialized by the provider when Create is called.
@@ -44,7 +44,7 @@ func (r *CredentialRequest) UnmarshalConfig(target interface{}) error {
 // hasValidCredentials returns true if there are already valid credentials
 // for the request. This is determined by the last resource state.
 func (r *CredentialRequest) hasValidCredentials(resource *Resource, rotationWindow time.Duration) bool {
-	now := time.Now()
+
 	if resource.Deposed {
 		return false
 	}
@@ -56,11 +56,11 @@ func (r *CredentialRequest) hasValidCredentials(resource *Resource, rotationWind
 	}
 
 	rotation := rotationWindow
-	if r.Rotation != 0 {
-		rotation = time.Duration(r.Rotation) * time.Second
+	if r.RotationWindow != 0 {
+		rotation = time.Duration(r.RotationWindow) * time.Second
 	}
 
-	if resource.Expiration.Add(-rotation).Before(now) {
+	if resource.Expiration.Add(-rotation).Before(time.Now()) {
 		return false
 	}
 

--- a/sidecred.go
+++ b/sidecred.go
@@ -24,8 +24,6 @@ type CredentialRequest struct {
 	// measured in seconds.
 	// This will aid in cases where we want to be more granular
 	// for possibly longer running authentications or processes.
-	//
-	// Needs to be a int because JSON unmarshalling does not support Duration
 	RotationWindow int `json:"rotation_window"`
 
 	// Config holds the specific configuration for the requested credential

--- a/sidecred.go
+++ b/sidecred.go
@@ -55,13 +55,15 @@ func (r *CredentialRequest) hasValidCredentials(resource *Resource, rotationWind
 		return false
 	}
 
-	if resource.Expiration.Add(time.Duration(-r.Rotation) * time.Minute).Before(now) {
+	rotation := rotationWindow
+	if r.Rotation != 0 {
+		rotation = time.Duration(r.Rotation) * time.Minute
+	}
+
+	if resource.Expiration.Add(-rotation).Before(now) {
 		return false
 	}
 
-	if resource.Expiration.Add(-rotationWindow).Before(now) {
-		return false
-	}
 	return true
 }
 

--- a/sidecred.go
+++ b/sidecred.go
@@ -21,7 +21,7 @@ type CredentialRequest struct {
 	Name string `json:"name"`
 
 	// Rotation is an override for the default rotation window
-	// measured in minutes.
+	// measured in seconds.
 	// This will aid in cases where we want to be more granular
 	// for possibly longer running authentications or processes.
 	//
@@ -57,7 +57,7 @@ func (r *CredentialRequest) hasValidCredentials(resource *Resource, rotationWind
 
 	rotation := rotationWindow
 	if r.Rotation != 0 {
-		rotation = time.Duration(r.Rotation) * time.Minute
+		rotation = time.Duration(r.Rotation) * time.Second
 	}
 
 	if resource.Expiration.Add(-rotation).Before(now) {

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -135,14 +135,14 @@ requests:
 - store: inprocess
   creds:
   - type: random
-    rotation: 5
+    rotation: 30
     name: fake.state.id
 			`),
 			resources: []*sidecred.Resource{{
 				Type:       sidecred.Randomized,
 				ID:         testStateID,
 				Store:      "inprocess",
-				Expiration: time.Now().Add(6 * time.Minute),
+				Expiration: time.Now().Add(29 * time.Minute),
 			}},
 			expectedResources: []*sidecred.Resource{{
 				Type:       sidecred.Randomized,
@@ -153,6 +153,39 @@ requests:
 			}},
 			expectedCreateCalls:  1,
 			expectedDestroyCalls: 1,
+		},
+		{
+			description: "does not replace resources (within the override rotation window)",
+			config: strings.TrimSpace(`
+---
+version: 1
+namespace: team-name
+
+stores:
+- type: inprocess
+
+requests:
+- store: inprocess
+  creds:
+  - type: random
+    rotation: 4
+    name: fake.state.id
+			`),
+			resources: []*sidecred.Resource{{
+				Type:       sidecred.Randomized,
+				ID:         testStateID,
+				Store:      "inprocess",
+				Expiration: testTime.Add(-55 * time.Minute),
+			}},
+			expectedResources: []*sidecred.Resource{{
+				Type:       sidecred.Randomized,
+				ID:         testStateID,
+				Store:      "inprocess",
+				Expiration: testTime.Add(-55 * time.Minute),
+				InUse:      true,
+			}},
+			expectedCreateCalls:  0,
+			expectedDestroyCalls: 0,
 		},
 		{
 			description: "destroys deposed resources",

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -135,7 +135,7 @@ requests:
 - store: inprocess
   creds:
   - type: random
-    rotation: 30
+    rotation: 1800 # 30 minutes
     name: fake.state.id
 			`),
 			resources: []*sidecred.Resource{{
@@ -168,7 +168,7 @@ requests:
 - store: inprocess
   creds:
   - type: random
-    rotation: 4
+    rotation: 240 # 4 minutes
     name: fake.state.id
 			`),
 			resources: []*sidecred.Resource{{

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -135,14 +135,14 @@ requests:
 - store: inprocess
   creds:
   - type: random
-    rotation: 15
+    rotation: 5
     name: fake.state.id
 			`),
 			resources: []*sidecred.Resource{{
 				Type:       sidecred.Randomized,
 				ID:         testStateID,
 				Store:      "inprocess",
-				Expiration: time.Now().Add(11 * time.Minute),
+				Expiration: time.Now().Add(6 * time.Minute),
 			}},
 			expectedResources: []*sidecred.Resource{{
 				Type:       sidecred.Randomized,

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -122,6 +122,39 @@ requests:
 			expectedDestroyCalls: 1,
 		},
 		{
+			description: "replaces expired resources (within the override rotation window)",
+			config: strings.TrimSpace(`
+---
+version: 1
+namespace: team-name
+
+stores:
+- type: inprocess
+
+requests:
+- store: inprocess
+  creds:
+  - type: random
+    rotation: 15
+    name: fake.state.id
+			`),
+			resources: []*sidecred.Resource{{
+				Type:       sidecred.Randomized,
+				ID:         testStateID,
+				Store:      "inprocess",
+				Expiration: time.Now().Add(11 * time.Minute),
+			}},
+			expectedResources: []*sidecred.Resource{{
+				Type:       sidecred.Randomized,
+				ID:         testStateID,
+				Store:      "inprocess",
+				Expiration: testTime,
+				InUse:      true,
+			}},
+			expectedCreateCalls:  1,
+			expectedDestroyCalls: 1,
+		},
+		{
 			description: "destroys deposed resources",
 			config: strings.TrimSpace(`
 ---

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -155,7 +155,7 @@ requests:
 			expectedDestroyCalls: 1,
 		},
 		{
-			description: "does not replace resources (within the override rotation window)",
+			description: "does not replace resources (outside the rotation window)",
 			config: strings.TrimSpace(`
 ---
 version: 1

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -135,7 +135,7 @@ requests:
 - store: inprocess
   creds:
   - type: random
-    rotation: 1800 # 30 minutes
+    rotation_window: 1800 # 30 minutes
     name: fake.state.id
 			`),
 			resources: []*sidecred.Resource{{
@@ -168,7 +168,7 @@ requests:
 - store: inprocess
   creds:
   - type: random
-    rotation: 240 # 4 minutes
+    rotation_window: 240 # 4 minutes
     name: fake.state.id
 			`),
 			resources: []*sidecred.Resource{{


### PR DESCRIPTION
In https://github.com/telia-oss/sidecred/issues/57 I outlined a need to override the rotation period from the default window for some credentials. I add a value to the CredentialsRequest which takes a time in minutes to do the override. Tests have been added to test expanding and contracting the override window through this override. 

Outstanding question is if the location of the `rotation` field makes sense. It is optional and shouldn't cause any issues. Please let me know if there are any changes that are needed.