### PR TITLE
Add support for durations in config (closes #59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ requests:
         name: open-source-dev-read-only
         config:
           role_arn: arn:aws:iam::role/role-name
-          duration: 900
+          duration: 15m
   - store: secretsmanager
     creds:
       - type: github:access-token

--- a/cmd/sidecred/testdata/config.yml
+++ b/cmd/sidecred/testdata/config.yml
@@ -7,25 +7,25 @@ stores:
   - type: ssm
 
 requests:
-  - store: ssm 
+  - store: ssm
     creds:
-    - type: aws:sts
-      name: open-source-dev-read-only
-      config:
-        role_arn: arn:aws:iam::role/role-name
-        duration: 900
-    - type: github:access-token
-      name: itsdalmo-access-token
-      config:
-        owner: itsdalmo
-        repositories:
-          - dotfiles
-        permissions:
-          contents: read
-    - type: github:deploy-key
-      name: dotfiles-deploy-key
-      config:
-        title: sidecred-test
-        owner: itsdalmo
-        repository: dotfiles
-        read_only: true
+      - type: aws:sts
+        name: open-source-dev-read-only
+        config:
+          role_arn: arn:aws:iam::role/role-name
+          duration: 15m
+      - type: github:access-token
+        name: itsdalmo-access-token
+        config:
+          owner: itsdalmo
+          repositories:
+            - dotfiles
+          permissions:
+            contents: read
+      - type: github:deploy-key
+        name: dotfiles-deploy-key
+        config:
+          title: sidecred-test
+          owner: itsdalmo
+          repository: dotfiles
+          read_only: true

--- a/config_test.go
+++ b/config_test.go
@@ -36,7 +36,7 @@ requests:
       name: open-source-dev-read-only
       config:
         role_arn: arn:aws:iam::role/role-name
-        duration: 900
+        duration: 15m
             `),
 			expected:                "",
 			expectedRequestCount:    1,
@@ -60,7 +60,7 @@ requests:
       - name: open-source-dev-read-only
         config:
           role_arn: arn:aws:iam::role/role-name
-          duration: 900
+          duration: 15m
             `),
 			expected:                "",
 			expectedRequestCount:    1,
@@ -86,7 +86,7 @@ requests:
       - name: open-source-dev-read-only
         config:
           role_arn: arn:aws:iam::role/role-name
-          duration: 900
+          duration: 15m
             `),
 			expected:                "",
 			expectedRequestCount:    1,
@@ -110,7 +110,7 @@ requests:
       name: open-source-dev-read-only
       config:
         role_arn: arn:aws:iam::role/role-name
-        duration: 900
+        duration: 15m
     - type: aws:sts
       name: open-source-dev-read-only
             `),

--- a/provider/artifactory/artifactory.go
+++ b/provider/artifactory/artifactory.go
@@ -61,7 +61,7 @@ type RequestConfig struct {
 	Group string `json:"group"`
 
 	// Request-specific override for credential duration.
-	Duration int `json:"duration"`
+	Duration *sidecred.Duration `json:"duration"`
 }
 
 // NewClient returns a new client for ArtifactoryAPI.
@@ -123,8 +123,8 @@ func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Cred
 		return nil, nil, err
 	}
 	duration := int(p.sessionDuration.Seconds())
-	if c.Duration != 0 {
-		duration = c.Duration
+	if c.Duration != nil {
+		duration = int(c.Duration.Seconds())
 	}
 
 	params := services.CreateTokenParams{

--- a/provider/artifactory/artifactory_test.go
+++ b/provider/artifactory/artifactory_test.go
@@ -49,7 +49,7 @@ func TestArtifactoryProvider(t *testing.T) {
 			request: &sidecred.CredentialRequest{
 				Type:   sidecred.AWSSTS,
 				Name:   "request-name",
-				Config: []byte(`{"user": "some-user", "group": "some-artifactory-group", "duration": 60}`),
+				Config: []byte(`{"user": "some-user", "group": "some-artifactory-group", "duration": "60s"}`),
 			},
 		},
 	}

--- a/provider/sts/sts.go
+++ b/provider/sts/sts.go
@@ -14,8 +14,8 @@ import (
 
 // RequestConfig ...
 type RequestConfig struct {
-	RoleARN  string `json:"role_arn"`
-	Duration int64  `json:"duration"`
+	RoleARN  string             `json:"role_arn"`
+	Duration *sidecred.Duration `json:"duration"`
 }
 
 // NewClient returns a new client for STSAPI.
@@ -70,8 +70,8 @@ func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Cred
 		return nil, nil, err
 	}
 	duration := int64(p.sessionDuration.Seconds())
-	if c.Duration != 0 {
-		duration = c.Duration
+	if c.Duration != nil {
+		duration = int64(c.Duration.Seconds())
 	}
 	input := &sts.AssumeRoleInput{
 		RoleSessionName: aws.String(request.Name),

--- a/provider/sts/sts_test.go
+++ b/provider/sts/sts_test.go
@@ -59,7 +59,7 @@ func TestSTSProvider(t *testing.T) {
 			request: &sidecred.CredentialRequest{
 				Type:   sidecred.AWSSTS,
 				Name:   "request-name",
-				Config: []byte(`{"role_arn": "request-role-arn", "duration":60}`),
+				Config: []byte(`{"role_arn": "request-role-arn", "duration":"60s"}`),
 			},
 		},
 	}

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -135,7 +135,7 @@ requests:
 - store: inprocess
   creds:
   - type: random
-    rotation_window: 1800 # 30 minutes
+    rotation_window: 30m
     name: fake.state.id
 			`),
 			resources: []*sidecred.Resource{{
@@ -168,7 +168,7 @@ requests:
 - store: inprocess
   creds:
   - type: random
-    rotation_window: 240 # 4 minutes
+    rotation_window: 240s
     name: fake.state.id
 			`),
 			resources: []*sidecred.Resource{{


### PR DESCRIPTION
As per the topic, this PR adds support for specifying a duration in a more user friendly way: `30s`, `15m`, `1h` etc. Tests pass, but this was cobbled together so I'm sure I've missed something 😄 