### PR TITLE
Add collaborators to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default. Unless we have a more specific match.
-*       @telia-oss/golang-owners
+*       @telia-oss/golang-owners @itsdalmo @mikael-lindstrom


### PR DESCRIPTION
Since SSO was enabled on the organisation, collaborators (@mikael-lindstrom and I) need to be added to CODEOWNERS in order to approve PRs.