### PR TITLE
Add required parameters to example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,5 +129,5 @@ After setting the above you can execute `sidecred` as follows:
 ```bash
 # The Github App credentials (integration ID and private key) and AWS STS credentials
 # should be populated using e.g. vaulted or aws-vault:
-go run ./cmd/sidecred --config ./cmd/sidecred/testdata/config.yml
+go run ./cmd/sidecred --config ./cmd/sidecred/testdata/config.yml --state-backend file  --state state.json
 ```


### PR DESCRIPTION
It will not run without these:

```
❯ go run ./cmd/sidecred --config ./cmd/sidecred/testdata/config.yml
sidecred: error: required flag --state-backend not provided, try --help
exit status 1
```