### PR TITLE
Fix flatten to avoid mutating config on validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -175,8 +175,12 @@ func (c *credentialRequest) flatten() []*sidecred.CredentialRequest {
 	}
 	var requests []*sidecred.CredentialRequest
 	for _, r := range c.List {
-		r.Type = c.CredentialRequest.Type
-		requests = append(requests, r)
+		requests = append(requests, &sidecred.CredentialRequest{
+			Type:           c.CredentialRequest.Type,
+			Name:           r.Name,
+			RotationWindow: r.RotationWindow,
+			Config:         r.Config,
+		})
 	}
 	return requests
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -167,3 +167,36 @@ requests:
 		})
 	}
 }
+
+// Ref: https://github.com/telia-oss/sidecred/pull/69
+func TestV1Config_validate_side_effects(t *testing.T) {
+	cfg := strings.TrimSpace(`
+---
+version: 1
+namespace: cloudops
+
+stores:
+  - type: secretsmanager
+
+requests:
+  - store: secretsmanager
+    creds:
+    - type: aws:sts
+      list:
+      - name: open-source-dev-read-only
+        config:
+          role_arn: arn:aws:iam::role/role-name
+          duration: 15m
+            `)
+
+	want, err := config.Parse([]byte(cfg))
+	require.NoError(t, err)
+
+	actual, err := config.Parse([]byte(cfg))
+	require.NoError(t, err)
+
+	err = actual.Validate()
+	require.NoError(t, err)
+
+	require.Equal(t, want, actual, "validate should not mutate config")
+}


### PR DESCRIPTION
This fixes the problem described in #69; the `flatten()` method had side effects, and calling `Validate()` would mutate the config and subsequent calls to `Validate()` would fail.

~Should add a test to cover this behavior before we merge~ 👍