### PR TITLE
Fix multiple binaries in goreleaser archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with: { go-version: 1.17 }
       - name: Release
         uses: goreleaser/goreleaser-action@v2
-        with: { version: v0.136.0, args: release --rm-dist }
+        with: { version: v1.3.1, args: release --rm-dist }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure AWS

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@ before:
 
 builds:
   - main: ./cmd/sidecred/main.go
+    id: sidecred
     <<: &config
       env:
         - CGO_ENABLED=0
@@ -24,6 +25,9 @@ builds:
 
 archives:
   - name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+    id: sidecred
+    builds:
+      - sidecred
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
Update `goreleaser` version to `v1.3.1`, and also fix an error with the archives in the config which produced an error:
```
error=invalid archive: 0: archive has different count of built binaries for each platform, which may cause your users confusion. Please make sure all builds used have the same set of goos/goarch/etc or split it into multiple archives
```

It seems like the `sidecred-lambda` was getting included in the `sidecred` archive for Linux (on newer versions of `goreleaser`). 