### PR TITLE
Remove linters that will be deprecated (soon)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
   enable:
     - bidichk
     - contextcheck
-    - deadcode
     - errcheck
     - errorlint
     - exhaustive
@@ -22,14 +21,12 @@ linters:
     - ineffassign
     - misspell
     - staticcheck
-    - structcheck
     - stylecheck
     - tenv
     - testpackage
     - thelper
     - typecheck
     - unused
-    - varcheck
     - wastedassign
 
 linters-settings:


### PR DESCRIPTION
Details here:
https://github.com/golangci/golangci-lint/issues/1841

The `unused` linter has the same functionality, so nothing we don't lose anything by removing these.