### PR TITLE
Add Sidecred credentials to GH Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,6 @@ jobs:
         with: { version: v1.3.1, args: release --rm-dist }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
       - name: Get version
         id: version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
@@ -35,3 +29,7 @@ jobs:
           aws s3 cp "dist/sidecred-lambda-${VERSION}-linux-amd64.zip" "s3://telia-oss/sidecred-lambda/v${VERSION}.zip" --acl public-read
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CONTRIBUTORS_TELIA_COMMON_OPENSOURCE_PROD_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CONTRIBUTORS_TELIA_COMMON_OPENSOURCE_PROD_SECRET_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.CONTRIBUTORS_TELIA_COMMON_OPENSOURCE_PROD_SESSION_TOKEN }}
+          AWS_REGION: "eu-west-1


### PR DESCRIPTION
This PR changes the credentials to use sidecred credentials issued for the new `telia-oss-sidecred`role deployed in `telia-common-opensource-prod` which is allowed to update our release buckets.