### PR TITLE
Add support for token naming in configuration file

### DIFF
--- a/provider/github/github.go
+++ b/provider/github/github.go
@@ -51,8 +51,10 @@ func (c *DeployKeyRequestConfig) Validate() error {
 // AccessTokenRequestConfig ...
 type AccessTokenRequestConfig struct {
 	Owner        string                 `json:"owner"`
+	TeamName     string 				`json:"team_name,omitempty"`
 	Repositories []string               `json:"repositories,omitempty"`
 	Permissions  *githubapp.Permissions `json:"permissions,omitempty"`
+	TokenName 	 string					`json:"token_name,omitempty"`
 }
 
 // Validate implements sidecred.Validatable.
@@ -138,8 +140,13 @@ func (p *provider) createAccessToken(request *sidecred.CredentialRequest) ([]*si
 	if err != nil {
 		return nil, nil, fmt.Errorf("create access token: %s", err)
 	}
+
+	tokenName := c.Owner + "-access-token"
+	if c.TokenName != "" && c.TeamName != "" {
+		tokenName = c.TeamName + "/" + c.TokenName
+	}
 	return []*sidecred.Credential{{
-		Name:        c.Owner + "-access-token",
+		Name:        tokenName,
 		Value:       token.GetToken(),
 		Description: "Github access token managed by sidecred.",
 		Expiration:  token.GetExpiresAt().UTC(),

--- a/provider/github/github.go
+++ b/provider/github/github.go
@@ -53,7 +53,7 @@ type AccessTokenRequestConfig struct {
 	Owner        string                 `json:"owner"`
 	Repositories []string               `json:"repositories,omitempty"`
 	Permissions  *githubapp.Permissions `json:"permissions,omitempty"`
-	TokenName 	 string					`json:"token_name,omitempty"`
+	TokenName    string		    `json:"token_name,omitempty"`
 }
 
 // Validate implements sidecred.Validatable.

--- a/provider/github/github.go
+++ b/provider/github/github.go
@@ -51,7 +51,6 @@ func (c *DeployKeyRequestConfig) Validate() error {
 // AccessTokenRequestConfig ...
 type AccessTokenRequestConfig struct {
 	Owner        string                 `json:"owner"`
-	TeamName     string 				`json:"team_name,omitempty"`
 	Repositories []string               `json:"repositories,omitempty"`
 	Permissions  *githubapp.Permissions `json:"permissions,omitempty"`
 	TokenName 	 string					`json:"token_name,omitempty"`
@@ -141,9 +140,10 @@ func (p *provider) createAccessToken(request *sidecred.CredentialRequest) ([]*si
 		return nil, nil, fmt.Errorf("create access token: %s", err)
 	}
 
+	// If token_name is not provided, use default token naming
 	tokenName := c.Owner + "-access-token"
-	if c.TokenName != "" && c.TeamName != "" {
-		tokenName = c.TeamName + "/" + c.TokenName
+	if c.TokenName != "" {
+		tokenName = c.TokenName
 	}
 	return []*sidecred.Credential{{
 		Name:        tokenName,

--- a/provider/github/github_test.go
+++ b/provider/github/github_test.go
@@ -60,7 +60,7 @@ func TestGithubProvider(t *testing.T) {
 			request: &sidecred.CredentialRequest{
 				Type:   sidecred.GithubAccessToken,
 				Name:   "request-name",
-				Config: []byte(`{"owner":"request-owner", "team_name":"test-team", "token_name": "test-token"}`),
+				Config: []byte(`{"owner":"request-owner", "token_name": "test-team/test-token"}`),
 			},
 			expected: []*sidecred.Credential{{
 				Name:        "test-team/test-token",

--- a/provider/github/github_test.go
+++ b/provider/github/github_test.go
@@ -55,6 +55,19 @@ func TestGithubProvider(t *testing.T) {
 				Description: "Github access token managed by sidecred.",
 			}},
 		},
+		{
+			description: "Github provider works for access tokens with team and token name specified",
+			request: &sidecred.CredentialRequest{
+				Type:   sidecred.GithubAccessToken,
+				Name:   "request-name",
+				Config: []byte(`{"owner":"request-owner", "team_name":"test-team", "token_name": "test-token"}`),
+			},
+			expected: []*sidecred.Credential{{
+				Name:        "test-team/test-token",
+				Value:       "access-token",
+				Description: "Github access token managed by sidecred.",
+			}},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
As written in #76 I would love to have a way to name my tokens so that I am able to have multiple Concourse teams use the same sidecred-lambda function.

Changes:
- added TokenName to AccessTokenRequestConfig struct in Github provider
- added another Test to check that this token generation works (also tested manually as part of my project)
