### PR TITLE
Improve sidecred logging

### DIFF
--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -2,6 +2,7 @@
 package file
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,7 +18,7 @@ func New() sidecred.StateBackend {
 type fileStateBackend struct{}
 
 // Load implements sidecred.StateBackend.
-func (b *fileStateBackend) Load(file string) (*sidecred.State, error) {
+func (b *fileStateBackend) Load(ctx context.Context, file string) (*sidecred.State, error) {
 	if err := b.createFileIfNotExists(file); err != nil {
 		return nil, err
 	}
@@ -36,7 +37,7 @@ func (b *fileStateBackend) Load(file string) (*sidecred.State, error) {
 }
 
 // Save implements sidecred.StateBackend.
-func (b *fileStateBackend) Save(file string, state *sidecred.State) error {
+func (b *fileStateBackend) Save(ctx context.Context, file string, state *sidecred.State) error {
 	if err := b.createFileIfNotExists(file); err != nil {
 		return err
 	}

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -4,6 +4,7 @@ package s3
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -36,7 +37,7 @@ type backend struct {
 }
 
 // Load implements sidecred.StateBackend.
-func (b *backend) Load(key string) (*sidecred.State, error) {
+func (b *backend) Load(ctx context.Context, key string) (*sidecred.State, error) {
 	var state sidecred.State
 	obj, err := b.client.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(b.bucket),
@@ -64,7 +65,7 @@ func (b *backend) Load(key string) (*sidecred.State, error) {
 }
 
 // Save implements sidecred.StateBackend.
-func (b *backend) Save(key string, state *sidecred.State) error {
+func (b *backend) Save(ctx context.Context, key string, state *sidecred.State) error {
 	o, err := json.Marshal(state)
 	if err != nil {
 		return err

--- a/backend/s3/s3_test.go
+++ b/backend/s3/s3_test.go
@@ -1,6 +1,7 @@
 package s3_test
 
 import (
+	"context"
 	"io"
 	"strings"
 	"testing"
@@ -29,7 +30,7 @@ func TestS3Backend(t *testing.T) {
 			fakeS3.GetObjectReturns(&s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader("{}"))}, nil)
 
 			b := backend.New(fakeS3, "bucket")
-			state, err := b.Load("key")
+			state, err := b.Load(context.TODO(), "key")
 			require.NoError(t, err)
 			assert.Equal(t, &sidecred.State{}, state)
 		})

--- a/cmd/sidecred/main.go
+++ b/cmd/sidecred/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -42,6 +43,8 @@ func main() {
 
 func runFunc(cfg, statePath *string) func(*sidecred.Sidecred, sidecred.StateBackend) error {
 	return func(s *sidecred.Sidecred, backend sidecred.StateBackend) error {
+		ctx := context.Background()
+
 		b, err := os.ReadFile(*cfg)
 		if err != nil {
 			return fmt.Errorf("failed to read config: %s", err)
@@ -50,14 +53,14 @@ func runFunc(cfg, statePath *string) func(*sidecred.Sidecred, sidecred.StateBack
 		if err != nil {
 			return fmt.Errorf("failed to parse config: %s", err)
 		}
-		state, err := backend.Load(*statePath)
+		state, err := backend.Load(ctx, *statePath)
 		if err != nil {
 			return fmt.Errorf("failed to load state: %s", err)
 		}
-		if err := s.Process(cfg, state); err != nil {
+		if err := s.Process(ctx, cfg, state); err != nil {
 			return err
 		}
-		if err := backend.Save(*statePath, state); err != nil {
+		if err := backend.Save(ctx, *statePath, state); err != nil {
 			return fmt.Errorf("failed to save state: %s", err)
 		}
 		return nil

--- a/cmd/sidecred/main.go
+++ b/cmd/sidecred/main.go
@@ -41,8 +41,8 @@ func main() {
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }
 
-func runFunc(cfg, statePath *string) func(*sidecred.Sidecred, sidecred.StateBackend) error {
-	return func(s *sidecred.Sidecred, backend sidecred.StateBackend) error {
+func runFunc(cfg, statePath *string) func(*sidecred.Sidecred, sidecred.StateBackend, sidecred.RunConfig) error {
+	return func(s *sidecred.Sidecred, backend sidecred.StateBackend, runConfig sidecred.RunConfig) error {
 		ctx := context.Background()
 
 		b, err := os.ReadFile(*cfg)

--- a/eventctx/context.go
+++ b/eventctx/context.go
@@ -1,0 +1,28 @@
+package eventctx
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+var loggerKey = struct{}{}
+
+func GetLogger(ctx context.Context) *zap.Logger {
+	logger, ok := ctx.Value(loggerKey).(*zap.Logger)
+	if !ok {
+		return zap.NewNop()
+	}
+
+	return logger
+}
+
+func SetLogger(ctx context.Context, logger *zap.Logger) context.Context {
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+func TestContext(t *testing.T) context.Context {
+	return SetLogger(context.TODO(), zaptest.NewLogger(t))
+}

--- a/eventctx/context.go
+++ b/eventctx/context.go
@@ -8,7 +8,18 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-var loggerKey = struct{}{}
+var (
+	loggerKey = struct{}{}
+	statsKey  = struct{}{}
+)
+
+type Stats struct {
+	CallsToGithub int
+}
+
+func (s *Stats) IncGithubCalls() {
+	s.CallsToGithub++
+}
 
 func GetLogger(ctx context.Context) *zap.Logger {
 	logger, ok := ctx.Value(loggerKey).(*zap.Logger)
@@ -25,4 +36,17 @@ func SetLogger(ctx context.Context, logger *zap.Logger) context.Context {
 
 func TestContext(t *testing.T) context.Context {
 	return SetLogger(context.TODO(), zaptest.NewLogger(t))
+}
+
+func GetStats(ctx context.Context) *Stats {
+	stats, ok := ctx.Value(statsKey).(*Stats)
+	if !ok {
+		return &Stats{}
+	}
+
+	return stats
+}
+
+func SetStats(ctx context.Context, stats *Stats) context.Context {
+	return context.WithValue(ctx, statsKey, stats)
 }

--- a/githubrotator/rotator.go
+++ b/githubrotator/rotator.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/go-github/v45/github"
 	"github.com/telia-oss/githubapp"
 	"go.uber.org/zap"
+
+	"github.com/telia-oss/sidecred/eventctx"
 )
 
 const (
@@ -102,6 +104,7 @@ func (r *Rotator) createInstallationToken(ctx context.Context, owner string, rep
 		r.logger.Debug("create installation token",
 			zap.String("app", r.apps[0].integrationID))
 
+		eventctx.GetStats(ctx).IncGithubCalls()
 		var rateLimitError *github.RateLimitError
 		token, err := r.apps[0].app.CreateInstallationToken(owner, repositories, permissions)
 		switch {

--- a/githubrotator/rotator.go
+++ b/githubrotator/rotator.go
@@ -45,13 +45,13 @@ type Rotator struct {
 	rateLimitClient RateLimits
 }
 
-func (r *Rotator) CreateInstallationToken(owner string, repositories []string, permissions *githubapp.Permissions) (*githubapp.Token, error) {
+func (r *Rotator) CreateInstallationToken(ctx context.Context, owner string, repositories []string, permissions *githubapp.Permissions) (*githubapp.Token, error) {
 	if r.apps[0].hasValidToken() {
 		r.logger.Debug("retrieving rate limits for token",
 			zap.String("token_expires_at", r.apps[0].token.ExpiresAt.String()),
 			zap.String("app", r.apps[0].integrationID))
 
-		rateLimits, _, err := r.rateLimitClient.GetTokenRateLimits(context.TODO(), r.apps[0].token.GetToken())
+		rateLimits, _, err := r.rateLimitClient.GetTokenRateLimits(ctx, r.apps[0].token.GetToken())
 		switch {
 		case err != nil:
 			r.logger.Debug("unexpected error when retrieving rate limits",
@@ -77,14 +77,14 @@ func (r *Rotator) CreateInstallationToken(owner string, repositories []string, p
 		}
 	}
 
-	return r.createInstallationToken(owner, repositories, permissions)
+	return r.createInstallationToken(ctx, owner, repositories, permissions)
 }
 
 func hasTokenExpired(token *githubapp.Token) bool {
 	return token.ExpiresAt.Sub(time.Now()).Seconds() <= 5 //nolint:gosimple,gocritic
 }
 
-func (r *Rotator) createInstallationToken(owner string, repositories []string, permissions *githubapp.Permissions) (*githubapp.Token, error) {
+func (r *Rotator) createInstallationToken(ctx context.Context, owner string, repositories []string, permissions *githubapp.Permissions) (*githubapp.Token, error) {
 	r.logger.Debug("createInstallationToken called",
 		zap.String("app", r.apps[0].integrationID),
 		zap.Int("number_of_apps", len(r.apps)))

--- a/githubrotator/rotator_test.go
+++ b/githubrotator/rotator_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/telia-oss/githubapp"
 	"go.uber.org/zap"
 
+	"github.com/telia-oss/sidecred/eventctx"
 	"github.com/telia-oss/sidecred/githubrotator"
 	"github.com/telia-oss/sidecred/githubrotator/fakes"
 )
@@ -69,24 +70,24 @@ func TestRotator_CreateInstallationToken(t *testing.T) {
 	})
 
 	// App 0 called, returns RateLimitError, rotates, App 1 called, returns Error, rotates, App 2 called, returns tokenA
-	token, err := rotator.CreateInstallationToken("telia-oss", []string{"sidecred"}, nil)
+	token, err := rotator.CreateInstallationToken(eventctx.TestContext(t), "telia-oss", []string{"sidecred"}, nil)
 	fmt.Println("TOKEN", token)
 	fmt.Println("ERROR", err)
 	assert.Expect(token.GetToken()).To(Equal("a"))
 	assert.Expect(err).To(BeNil())
 
 	// tokenA GetTokenRateLimits called, returns low rate limit, rotate, App 0 by passed, App 1 called, returns tokenB
-	token, err = rotator.CreateInstallationToken("telia-oss", []string{"sidecred"}, nil)
+	token, err = rotator.CreateInstallationToken(eventctx.TestContext(t), "telia-oss", []string{"sidecred"}, nil)
 	assert.Expect(token.GetToken()).To(Equal("b"))
 	assert.Expect(err).To(BeNil())
 
 	// tokenB GetTokenRateLimits called, returns Error
-	token, err = rotator.CreateInstallationToken("telia-oss", []string{"sidecred"}, nil)
+	token, err = rotator.CreateInstallationToken(eventctx.TestContext(t), "telia-oss", []string{"sidecred"}, nil)
 	assert.Expect(token).To(BeNil())
 	assert.Expect(err).To(HaveOccurred())
 
 	// tokenB GetTokenRateLimits called, returns rate limit above cutoff, returns tokenC
-	token, err = rotator.CreateInstallationToken("telia-oss", []string{"sidecred"}, nil)
+	token, err = rotator.CreateInstallationToken(eventctx.TestContext(t), "telia-oss", []string{"sidecred"}, nil)
 	assert.Expect(token).To(Equal(tokenC))
 	assert.Expect(err).To(BeNil())
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -30,7 +30,7 @@ import (
 // Type definitions that allow us to reuse the CLI (flags and setup) between binaries, and
 // also so we can pass in test fakes during testing.
 type (
-	runFunc          func(*sidecred.Sidecred, sidecred.StateBackend) error
+	runFunc          func(*sidecred.Sidecred, sidecred.StateBackend, sidecred.RunConfig) error
 	awsClientFactory func() (s3.S3API, sts.STSAPI, ssm.SSMAPI, secretsmanager.SecretsManagerAPI)
 	loggerFactory    func(bool) (*zap.Logger, error)
 )
@@ -174,11 +174,11 @@ func AddRunCommand(app *kingpin.Application, run runFunc, newAWSClient awsClient
 			logger.Fatal("unknown state backend", zap.String("backend", *stateBackend))
 		}
 
-		s, err := sidecred.New(providers, stores, *rotationWindow, logger)
+		s, err := sidecred.New(providers, stores, *rotationWindow)
 		if err != nil {
 			logger.Fatal("initialize sidecred", zap.Error(err))
 		}
-		if err := run(s, backend); err != nil {
+		if err := run(s, backend, sidecred.RunConfig{Logger: logger}); err != nil {
 			logger.Fatal("run failed", zap.Error(err))
 		}
 		return nil

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -146,7 +146,6 @@ func AddRunCommand(app *kingpin.Application, run runFunc, newAWSClient awsClient
 					PrivateKeys:    strings.Split(*githubStorePrivateKey, ","),
 					Logger:         logger,
 				}),
-				logger,
 				githubstore.WithSecretTemplate(*githubStoreSecretTemplate),
 			))
 		}
@@ -158,7 +157,6 @@ func AddRunCommand(app *kingpin.Application, run runFunc, newAWSClient awsClient
 					PrivateKeys:    strings.Split(*githubDependabotStorePrivateKey, ","),
 					Logger:         logger,
 				}),
-				logger,
 				githubstore.WithSecretTemplate(*githubDependabotStoreSecretTemplate),
 			))
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -83,7 +84,7 @@ requests:
 				if err != nil {
 					return fmt.Errorf("failed to parse config: %s", err)
 				}
-				return s.Process(c, &sidecred.State{})
+				return s.Process(context.TODO(), c, &sidecred.State{})
 			}
 
 			app := kingpin.New("test", "").Terminate(nil)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/telia-oss/sidecred/backend/s3"
 	"github.com/telia-oss/sidecred/backend/s3/s3fakes"
 	"github.com/telia-oss/sidecred/config"
+	"github.com/telia-oss/sidecred/eventctx"
 	"github.com/telia-oss/sidecred/internal/cli"
 	"github.com/telia-oss/sidecred/provider/sts"
 	"github.com/telia-oss/sidecred/provider/sts/stsfakes"
@@ -79,12 +80,17 @@ requests:
         length: 10
             `)
 
-			runFunc := func(s *sidecred.Sidecred, _ sidecred.StateBackend) error {
+			runFunc := func(s *sidecred.Sidecred, _ sidecred.StateBackend, runConfig sidecred.RunConfig) error {
 				c, err := config.Parse([]byte(cfg))
 				if err != nil {
 					return fmt.Errorf("failed to parse config: %s", err)
 				}
-				return s.Process(context.TODO(), c, &sidecred.State{})
+
+				ctx := eventctx.SetLogger(context.TODO(), runConfig.Logger.With(
+					zap.String("namespace", "example"),
+				))
+
+				return s.Process(ctx, c, &sidecred.State{})
 			}
 
 			app := kingpin.New("test", "").Terminate(nil)

--- a/provider/artifactory/artifactory.go
+++ b/provider/artifactory/artifactory.go
@@ -22,6 +22,7 @@ package artifactory
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -131,7 +132,7 @@ func (p *provider) Type() sidecred.ProviderType {
 }
 
 // Create implements sidecred.Provider.
-func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
+func (p *provider) Create(ctx context.Context, request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
 	var c RequestConfig
 	if err := request.UnmarshalConfig(&c); err != nil {
 		return nil, nil, err
@@ -173,7 +174,7 @@ func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Cred
 }
 
 // Destroy implements sidecred.Provider.
-func (p *provider) Destroy(_ *sidecred.Resource) error {
+func (p *provider) Destroy(_ context.Context, _ *sidecred.Resource) error {
 	return nil
 }
 

--- a/provider/artifactory/artifactory_test.go
+++ b/provider/artifactory/artifactory_test.go
@@ -1,6 +1,7 @@
 package artifactory_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -68,7 +69,7 @@ func TestArtifactoryProvider(t *testing.T) {
 				provider.WithSessionDuration(tc.sessionDuration),
 			)
 
-			creds, metadata, err := p.Create(tc.request)
+			creds, metadata, err := p.Create(context.TODO(), tc.request)
 			require.NoError(t, err)
 			require.Equal(t, 1, fakeArtifactoryAPI.CreateTokenCallCount())
 			require.Len(t, creds, len(expectedCredentials))

--- a/provider/github/github.go
+++ b/provider/github/github.go
@@ -135,7 +135,7 @@ func (p *provider) createAccessToken(ctx context.Context, request *sidecred.Cred
 	if c.Permissions != nil {
 		permissions = c.Permissions
 	}
-	token, err := p.app.CreateInstallationToken(c.Owner, c.Repositories, permissions)
+	token, err := p.app.CreateInstallationToken(ctx, c.Owner, c.Repositories, permissions)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create access token: %s", err)
 	}
@@ -158,7 +158,7 @@ func (p *provider) createDeployKey(ctx context.Context, request *sidecred.Creden
 	if err := request.UnmarshalConfig(&c); err != nil {
 		return nil, nil, err
 	}
-	token, err := p.app.CreateInstallationToken(c.Owner, []string{c.Repository}, &githubapp.Permissions{
+	token, err := p.app.CreateInstallationToken(ctx, c.Owner, []string{c.Repository}, &githubapp.Permissions{
 		Administration: github.String("write"), // Used to add deploy keys to repositories: https://developer.github.com/v3/apps/permissions/#permission-on-administration
 	})
 	if err != nil {
@@ -226,7 +226,7 @@ func (p *provider) Destroy(ctx context.Context, resource *sidecred.Resource) err
 	if err != nil {
 		return fmt.Errorf("failed to convert key id (%s) to int: %s", s, err)
 	}
-	token, err := p.app.CreateInstallationToken(c.Owner, []string{c.Repository}, &githubapp.Permissions{
+	token, err := p.app.CreateInstallationToken(ctx, c.Owner, []string{c.Repository}, &githubapp.Permissions{
 		Administration: github.String("write"), // Used to add deploy keys to repositories: https://developer.github.com/v3/apps/permissions/#permission-on-administration
 	})
 	if err != nil {
@@ -246,7 +246,7 @@ func (p *provider) Destroy(ctx context.Context, resource *sidecred.Resource) err
 //
 //counterfeiter:generate . App
 type App interface {
-	CreateInstallationToken(owner string, repositories []string, permissions *githubapp.Permissions) (*githubapp.Token, error)
+	CreateInstallationToken(ctx context.Context, owner string, repositories []string, permissions *githubapp.Permissions) (*githubapp.Token, error)
 }
 
 // RepositoriesAPI wraps the Github repositories API.

--- a/provider/github/github_test.go
+++ b/provider/github/github_test.go
@@ -1,6 +1,7 @@
 package github_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -84,7 +85,7 @@ func TestGithubProvider(t *testing.T) {
 				}),
 			)
 
-			creds, metadata, err := p.Create(tc.request)
+			creds, metadata, err := p.Create(context.TODO(), tc.request)
 			require.NoError(t, err)
 			require.Len(t, creds, len(tc.expected))
 			assert.Equal(t, tc.expectedMetadata, metadata)

--- a/provider/github/githubfakes/fake_app.go
+++ b/provider/github/githubfakes/fake_app.go
@@ -2,6 +2,7 @@
 package githubfakes
 
 import (
+	"context"
 	"sync"
 
 	"github.com/telia-oss/githubapp"
@@ -9,12 +10,13 @@ import (
 )
 
 type FakeApp struct {
-	CreateInstallationTokenStub        func(string, []string, *githubapp.Permissions) (*githubapp.Token, error)
+	CreateInstallationTokenStub        func(context.Context, string, []string, *githubapp.Permissions) (*githubapp.Token, error)
 	createInstallationTokenMutex       sync.RWMutex
 	createInstallationTokenArgsForCall []struct {
-		arg1 string
-		arg2 []string
-		arg3 *githubapp.Permissions
+		arg1 context.Context
+		arg2 string
+		arg3 []string
+		arg4 *githubapp.Permissions
 	}
 	createInstallationTokenReturns struct {
 		result1 *githubapp.Token
@@ -28,25 +30,26 @@ type FakeApp struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeApp) CreateInstallationToken(arg1 string, arg2 []string, arg3 *githubapp.Permissions) (*githubapp.Token, error) {
-	var arg2Copy []string
-	if arg2 != nil {
-		arg2Copy = make([]string, len(arg2))
-		copy(arg2Copy, arg2)
+func (fake *FakeApp) CreateInstallationToken(arg1 context.Context, arg2 string, arg3 []string, arg4 *githubapp.Permissions) (*githubapp.Token, error) {
+	var arg3Copy []string
+	if arg3 != nil {
+		arg3Copy = make([]string, len(arg3))
+		copy(arg3Copy, arg3)
 	}
 	fake.createInstallationTokenMutex.Lock()
 	ret, specificReturn := fake.createInstallationTokenReturnsOnCall[len(fake.createInstallationTokenArgsForCall)]
 	fake.createInstallationTokenArgsForCall = append(fake.createInstallationTokenArgsForCall, struct {
-		arg1 string
-		arg2 []string
-		arg3 *githubapp.Permissions
-	}{arg1, arg2Copy, arg3})
+		arg1 context.Context
+		arg2 string
+		arg3 []string
+		arg4 *githubapp.Permissions
+	}{arg1, arg2, arg3Copy, arg4})
 	stub := fake.CreateInstallationTokenStub
 	fakeReturns := fake.createInstallationTokenReturns
-	fake.recordInvocation("CreateInstallationToken", []interface{}{arg1, arg2Copy, arg3})
+	fake.recordInvocation("CreateInstallationToken", []interface{}{arg1, arg2, arg3Copy, arg4})
 	fake.createInstallationTokenMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -60,17 +63,17 @@ func (fake *FakeApp) CreateInstallationTokenCallCount() int {
 	return len(fake.createInstallationTokenArgsForCall)
 }
 
-func (fake *FakeApp) CreateInstallationTokenCalls(stub func(string, []string, *githubapp.Permissions) (*githubapp.Token, error)) {
+func (fake *FakeApp) CreateInstallationTokenCalls(stub func(context.Context, string, []string, *githubapp.Permissions) (*githubapp.Token, error)) {
 	fake.createInstallationTokenMutex.Lock()
 	defer fake.createInstallationTokenMutex.Unlock()
 	fake.CreateInstallationTokenStub = stub
 }
 
-func (fake *FakeApp) CreateInstallationTokenArgsForCall(i int) (string, []string, *githubapp.Permissions) {
+func (fake *FakeApp) CreateInstallationTokenArgsForCall(i int) (context.Context, string, []string, *githubapp.Permissions) {
 	fake.createInstallationTokenMutex.RLock()
 	defer fake.createInstallationTokenMutex.RUnlock()
 	argsForCall := fake.createInstallationTokenArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeApp) CreateInstallationTokenReturns(result1 *githubapp.Token, result2 error) {

--- a/provider/random/random.go
+++ b/provider/random/random.go
@@ -2,6 +2,7 @@
 package random
 
 import (
+	"context"
 	"math/rand"
 	"time"
 
@@ -54,7 +55,7 @@ func (p *provider) Type() sidecred.ProviderType {
 }
 
 // Create implements sidecred.Provider.
-func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
+func (p *provider) Create(ctx context.Context, request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
 	var c RequestConfig
 	if err := request.UnmarshalConfig(&c); err != nil {
 		return nil, nil, err
@@ -74,6 +75,6 @@ func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Cred
 }
 
 // Destroy implements sidecred.Provider.
-func (p *provider) Destroy(_ *sidecred.Resource) error {
+func (p *provider) Destroy(_ context.Context, _ *sidecred.Resource) error {
 	return nil
 }

--- a/provider/random/random_test.go
+++ b/provider/random/random_test.go
@@ -1,6 +1,7 @@
 package random_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,7 +65,7 @@ func TestRandomProvider(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			p := provider.New(tc.seed)
 
-			creds, metadata, err := p.Create(tc.request)
+			creds, metadata, err := p.Create(context.TODO(), tc.request)
 			require.NoError(t, err)
 			require.Len(t, creds, len(tc.expected))
 			assert.Nil(t, metadata)

--- a/provider/sts/sts.go
+++ b/provider/sts/sts.go
@@ -3,6 +3,7 @@ package sts
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -78,7 +79,7 @@ func (p *provider) Type() sidecred.ProviderType {
 }
 
 // Create implements sidecred.Provider.
-func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
+func (p *provider) Create(ctx context.Context, request *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
 	var c RequestConfig
 	if err := request.UnmarshalConfig(&c); err != nil {
 		return nil, nil, err
@@ -123,7 +124,7 @@ func (p *provider) Create(request *sidecred.CredentialRequest) ([]*sidecred.Cred
 }
 
 // Destroy implements sidecred.Provider.
-func (p *provider) Destroy(_ *sidecred.Resource) error {
+func (p *provider) Destroy(_ context.Context, _ *sidecred.Resource) error {
 	return nil
 }
 

--- a/provider/sts/sts_test.go
+++ b/provider/sts/sts_test.go
@@ -1,6 +1,7 @@
 package sts_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -82,7 +83,7 @@ func TestSTSProvider(t *testing.T) {
 				provider.WithExternalID(tc.externalID),
 			)
 
-			creds, metadata, err := p.Create(tc.request)
+			creds, metadata, err := p.Create(context.TODO(), tc.request)
 			require.NoError(t, err)
 			require.Equal(t, 1, fakeSTSAPI.AssumeRoleCallCount())
 			require.Len(t, creds, len(expectedCredentials))

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -1,6 +1,7 @@
 package sidecred_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -333,7 +334,7 @@ requests:
 			cfg, err := config.Parse([]byte(tc.config))
 			require.NoError(t, err)
 
-			err = s.Process(cfg, state)
+			err = s.Process(context.TODO(), cfg, state)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCreateCalls, provider.CreateCallCount(), "create calls")
 			assert.Equal(t, tc.expectedDestroyCalls, provider.DestroyCallCount(), "destroy calls")
@@ -343,7 +344,7 @@ requests:
 			}
 
 			for k, v := range tc.expectedSecrets {
-				value, found, err := store.Read(k, []byte("{}"))
+				value, found, err := store.Read(context.TODO(), k, []byte("{}"))
 				assert.NoError(t, err)
 				assert.True(t, found, "secret exists")
 				assert.Equal(t, v, value)
@@ -434,7 +435,7 @@ stores:
 			cfg, err := config.Parse([]byte(tc.config))
 			require.NoError(t, err)
 
-			err = s.Process(cfg, state)
+			err = s.Process(context.TODO(), cfg, state)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedDestroyCalls, provider.DestroyCallCount(), "destroy calls")
 
@@ -467,7 +468,7 @@ func (f *fakeProvider) Type() sidecred.ProviderType {
 	return sidecred.Random
 }
 
-func (f *fakeProvider) Create(_ *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
+func (f *fakeProvider) Create(_ context.Context, _ *sidecred.CredentialRequest) ([]*sidecred.Credential, *sidecred.Metadata, error) {
 	f.createCallCount++
 	return []*sidecred.Credential{{
 			Name:       "fake-credential",
@@ -478,7 +479,7 @@ func (f *fakeProvider) Create(_ *sidecred.CredentialRequest) ([]*sidecred.Creden
 		nil
 }
 
-func (f *fakeProvider) Destroy(_ *sidecred.Resource) error {
+func (f *fakeProvider) Destroy(_ context.Context, _ *sidecred.Resource) error {
 	f.destroyCallCount++
 	return nil
 }

--- a/sidecred_test.go
+++ b/sidecred_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 
 	"github.com/telia-oss/sidecred"
 	"github.com/telia-oss/sidecred/config"
+	"github.com/telia-oss/sidecred/eventctx"
 	"github.com/telia-oss/sidecred/store/inprocess"
 )
 
@@ -322,19 +322,18 @@ requests:
 				store    = inprocess.New()
 				state    = sidecred.NewState()
 				provider = &fakeProvider{}
-				logger   = zaptest.NewLogger(t)
 			)
 			for _, r := range tc.resources {
 				state.AddResource(r)
 			}
 
-			s, err := sidecred.New([]sidecred.Provider{provider}, []sidecred.SecretStore{store}, 10*time.Minute, logger)
+			s, err := sidecred.New([]sidecred.Provider{provider}, []sidecred.SecretStore{store}, 10*time.Minute)
 			require.NoError(t, err)
 
 			cfg, err := config.Parse([]byte(tc.config))
 			require.NoError(t, err)
 
-			err = s.Process(context.TODO(), cfg, state)
+			err = s.Process(eventctx.TestContext(t), cfg, state)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCreateCalls, provider.CreateCallCount(), "create calls")
 			assert.Equal(t, tc.expectedDestroyCalls, provider.DestroyCallCount(), "destroy calls")
@@ -344,7 +343,7 @@ requests:
 			}
 
 			for k, v := range tc.expectedSecrets {
-				value, found, err := store.Read(context.TODO(), k, []byte("{}"))
+				value, found, err := store.Read(eventctx.TestContext(t), k, []byte("{}"))
 				assert.NoError(t, err)
 				assert.True(t, found, "secret exists")
 				assert.Equal(t, v, value)
@@ -418,7 +417,6 @@ stores:
 				store    = inprocess.New()
 				state    = sidecred.NewState()
 				provider = &fakeProvider{}
-				logger   = zaptest.NewLogger(t)
 			)
 
 			for _, r := range tc.resources {
@@ -429,13 +427,13 @@ stores:
 				state.AddSecret(&sidecred.StoreConfig{Type: store.Type()}, s)
 			}
 
-			s, err := sidecred.New([]sidecred.Provider{provider}, []sidecred.SecretStore{store}, 10*time.Minute, logger)
+			s, err := sidecred.New([]sidecred.Provider{provider}, []sidecred.SecretStore{store}, 10*time.Minute)
 			require.NoError(t, err)
 
 			cfg, err := config.Parse([]byte(tc.config))
 			require.NoError(t, err)
 
-			err = s.Process(context.TODO(), cfg, state)
+			err = s.Process(eventctx.TestContext(t), cfg, state)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedDestroyCalls, provider.DestroyCallCount(), "destroy calls")
 

--- a/state.go
+++ b/state.go
@@ -1,6 +1,7 @@
 package sidecred
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"time"
@@ -9,10 +10,10 @@ import (
 // StateBackend is implemented by things that know how to store sidecred.State.
 type StateBackend interface {
 	// Load state from the backend. If no state exists it should be created.
-	Load(path string) (*State, error)
+	Load(ctx context.Context, path string) (*State, error)
 
 	// Save a state to the backend.
-	Save(path string, state *State) error
+	Save(ctx context.Context, path string, state *State) error
 }
 
 // NewState returns a new sidecred.State.

--- a/store/github/actions.go
+++ b/store/github/actions.go
@@ -2,15 +2,14 @@ package github
 
 import (
 	"github.com/telia-oss/githubapp"
-	"go.uber.org/zap"
 
 	"github.com/telia-oss/sidecred"
 )
 
-func NewActionsStore(app App, logger *zap.Logger, options ...Option) sidecred.SecretStore {
+func NewActionsStore(app App, options ...Option) sidecred.SecretStore {
 	options = append(options, forStoreType(sidecred.GithubSecrets), WithActionsClientFactory(func(token string) ActionsAPI {
 		return githubapp.NewInstallationClient(token).V3.Actions
 	}))
 
-	return NewStore(app, logger, options...)
+	return NewStore(app, options...)
 }

--- a/store/github/app.go
+++ b/store/github/app.go
@@ -1,6 +1,8 @@
 package github
 
 import (
+	"context"
+
 	"github.com/telia-oss/githubapp"
 )
 
@@ -8,7 +10,7 @@ import (
 //
 //counterfeiter:generate . App
 type App interface {
-	CreateInstallationToken(owner string, repositories []string, permissions *githubapp.Permissions) (
+	CreateInstallationToken(ctx context.Context, owner string, repositories []string, permissions *githubapp.Permissions) (
 		*githubapp.Token,
 		error,
 	)

--- a/store/github/dependabot.go
+++ b/store/github/dependabot.go
@@ -2,15 +2,14 @@ package github
 
 import (
 	"github.com/telia-oss/githubapp"
-	"go.uber.org/zap"
 
 	"github.com/telia-oss/sidecred"
 )
 
-func NewDependabotStore(app App, logger *zap.Logger, options ...Option) sidecred.SecretStore {
+func NewDependabotStore(app App, options ...Option) sidecred.SecretStore {
 	options = append(options, forStoreType(sidecred.GithubDependabotSecrets), WithActionsClientFactory(func(token string) ActionsAPI {
 		return githubapp.NewInstallationClient(token).V3.Dependabot
 	}))
 
-	return NewStore(app, logger, options...)
+	return NewStore(app, options...)
 }

--- a/store/github/github.go
+++ b/store/github/github.go
@@ -109,7 +109,7 @@ func (s *store) Write(ctx context.Context, namespace string, secret *sidecred.Cr
 	//
 	// It is not supported as of v32 of go-github:
 	// https://github.com/google/go-github/blob/v32.1.0/github/apps.go#L60
-	token, err := s.app.CreateInstallationToken(c.owner, []string{c.repository}, nil)
+	token, err := s.app.CreateInstallationToken(ctx, c.owner, []string{c.repository}, nil)
 	if err != nil {
 		return "", fmt.Errorf("create secrets access token: %w", err)
 	}
@@ -158,7 +158,7 @@ func (s *store) Read(ctx context.Context, path string, config json.RawMessage) (
 	if err != nil {
 		return "", false, fmt.Errorf("parse config: %w", err)
 	}
-	token, err := s.app.CreateInstallationToken(c.owner, []string{c.repository}, nil)
+	token, err := s.app.CreateInstallationToken(ctx, c.owner, []string{c.repository}, nil)
 	if err != nil {
 		return "", false, fmt.Errorf("create secrets access token: %w", err)
 	}
@@ -180,7 +180,7 @@ func (s *store) Delete(ctx context.Context, path string, config json.RawMessage)
 	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
-	token, err := s.app.CreateInstallationToken(c.owner, []string{c.repository}, nil)
+	token, err := s.app.CreateInstallationToken(ctx, c.owner, []string{c.repository}, nil)
 	if err != nil {
 		return fmt.Errorf("create secrets access token: %w", err)
 	}

--- a/store/github/github_test.go
+++ b/store/github/github_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/go-github/v45/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/telia-oss/githubapp"
-	"go.uber.org/zap/zaptest"
 
 	"github.com/telia-oss/sidecred"
 	secretstore "github.com/telia-oss/sidecred/store/github"
@@ -60,7 +59,6 @@ func TestWrite(t *testing.T) {
 			fakeActionsAPI.CreateOrUpdateRepoSecretReturns(nil, nil)
 
 			store := secretstore.NewStore(fakeApp,
-				zaptest.NewLogger(t),
 				secretstore.WithSecretTemplate(tc.secretTemplate),
 				secretstore.WithActionsClientFactory(func(string) secretstore.ActionsAPI {
 					return fakeActionsAPI
@@ -107,7 +105,6 @@ func TestRead(t *testing.T) {
 			fakeActionsAPI.GetRepoSecretReturns(&github.Secret{Name: secretValue}, nil, nil)
 
 			store := secretstore.NewStore(fakeApp,
-				zaptest.NewLogger(t),
 				secretstore.WithActionsClientFactory(func(string) secretstore.ActionsAPI {
 					return fakeActionsAPI
 				}),
@@ -147,7 +144,6 @@ func TestDelete(t *testing.T) {
 			fakeActionsAPI.DeleteRepoSecretReturns(nil, nil)
 
 			store := secretstore.NewStore(fakeApp,
-				zaptest.NewLogger(t),
 				secretstore.WithActionsClientFactory(func(string) secretstore.ActionsAPI {
 					return fakeActionsAPI
 				}),

--- a/store/github/github_test.go
+++ b/store/github/github_test.go
@@ -1,6 +1,7 @@
 package github_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -65,7 +66,7 @@ func TestWrite(t *testing.T) {
 					return fakeActionsAPI
 				}),
 			)
-			path, err := store.Write(teamName, secret, tc.config)
+			path, err := store.Write(context.TODO(), teamName, secret, tc.config)
 
 			assert.Equal(t, tc.expectedError, err)
 			assert.Equal(t, tc.secretPath, path)
@@ -111,7 +112,7 @@ func TestRead(t *testing.T) {
 					return fakeActionsAPI
 				}),
 			)
-			secret, found, err := store.Read(tc.secretPath, tc.config)
+			secret, found, err := store.Read(context.TODO(), tc.secretPath, tc.config)
 
 			assert.Equal(t, tc.expectedError, err)
 			assert.Equal(t, tc.expectFound, found)
@@ -151,7 +152,7 @@ func TestDelete(t *testing.T) {
 					return fakeActionsAPI
 				}),
 			)
-			err := store.Delete(tc.secretPath, tc.config)
+			err := store.Delete(context.TODO(), tc.secretPath, tc.config)
 
 			assert.Equal(t, tc.expectedError, err)
 			assert.Equal(t, 1, fakeActionsAPI.DeleteRepoSecretCallCount())

--- a/store/github/githubfakes/fake_app.go
+++ b/store/github/githubfakes/fake_app.go
@@ -2,6 +2,7 @@
 package githubfakes
 
 import (
+	"context"
 	"sync"
 
 	"github.com/telia-oss/githubapp"
@@ -9,12 +10,13 @@ import (
 )
 
 type FakeApp struct {
-	CreateInstallationTokenStub        func(string, []string, *githubapp.Permissions) (*githubapp.Token, error)
+	CreateInstallationTokenStub        func(context.Context, string, []string, *githubapp.Permissions) (*githubapp.Token, error)
 	createInstallationTokenMutex       sync.RWMutex
 	createInstallationTokenArgsForCall []struct {
-		arg1 string
-		arg2 []string
-		arg3 *githubapp.Permissions
+		arg1 context.Context
+		arg2 string
+		arg3 []string
+		arg4 *githubapp.Permissions
 	}
 	createInstallationTokenReturns struct {
 		result1 *githubapp.Token
@@ -28,25 +30,26 @@ type FakeApp struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeApp) CreateInstallationToken(arg1 string, arg2 []string, arg3 *githubapp.Permissions) (*githubapp.Token, error) {
-	var arg2Copy []string
-	if arg2 != nil {
-		arg2Copy = make([]string, len(arg2))
-		copy(arg2Copy, arg2)
+func (fake *FakeApp) CreateInstallationToken(arg1 context.Context, arg2 string, arg3 []string, arg4 *githubapp.Permissions) (*githubapp.Token, error) {
+	var arg3Copy []string
+	if arg3 != nil {
+		arg3Copy = make([]string, len(arg3))
+		copy(arg3Copy, arg3)
 	}
 	fake.createInstallationTokenMutex.Lock()
 	ret, specificReturn := fake.createInstallationTokenReturnsOnCall[len(fake.createInstallationTokenArgsForCall)]
 	fake.createInstallationTokenArgsForCall = append(fake.createInstallationTokenArgsForCall, struct {
-		arg1 string
-		arg2 []string
-		arg3 *githubapp.Permissions
-	}{arg1, arg2Copy, arg3})
+		arg1 context.Context
+		arg2 string
+		arg3 []string
+		arg4 *githubapp.Permissions
+	}{arg1, arg2, arg3Copy, arg4})
 	stub := fake.CreateInstallationTokenStub
 	fakeReturns := fake.createInstallationTokenReturns
-	fake.recordInvocation("CreateInstallationToken", []interface{}{arg1, arg2Copy, arg3})
+	fake.recordInvocation("CreateInstallationToken", []interface{}{arg1, arg2, arg3Copy, arg4})
 	fake.createInstallationTokenMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -60,17 +63,17 @@ func (fake *FakeApp) CreateInstallationTokenCallCount() int {
 	return len(fake.createInstallationTokenArgsForCall)
 }
 
-func (fake *FakeApp) CreateInstallationTokenCalls(stub func(string, []string, *githubapp.Permissions) (*githubapp.Token, error)) {
+func (fake *FakeApp) CreateInstallationTokenCalls(stub func(context.Context, string, []string, *githubapp.Permissions) (*githubapp.Token, error)) {
 	fake.createInstallationTokenMutex.Lock()
 	defer fake.createInstallationTokenMutex.Unlock()
 	fake.CreateInstallationTokenStub = stub
 }
 
-func (fake *FakeApp) CreateInstallationTokenArgsForCall(i int) (string, []string, *githubapp.Permissions) {
+func (fake *FakeApp) CreateInstallationTokenArgsForCall(i int) (context.Context, string, []string, *githubapp.Permissions) {
 	fake.createInstallationTokenMutex.RLock()
 	defer fake.createInstallationTokenMutex.RUnlock()
 	argsForCall := fake.createInstallationTokenArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeApp) CreateInstallationTokenReturns(result1 *githubapp.Token, result2 error) {

--- a/store/inprocess/inprocess.go
+++ b/store/inprocess/inprocess.go
@@ -2,6 +2,7 @@
 package inprocess
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -45,7 +46,7 @@ func (s *store) Type() sidecred.StoreType {
 }
 
 // Write implements secretstore.SecretStore.
-func (s *store) Write(namespace string, secret *sidecred.Credential, config json.RawMessage) (string, error) {
+func (s *store) Write(ctx context.Context, namespace string, secret *sidecred.Credential, config json.RawMessage) (string, error) {
 	c, err := s.parseConfig(config)
 	if err != nil {
 		return "", fmt.Errorf("parse config: %s", err)
@@ -60,7 +61,7 @@ func (s *store) Write(namespace string, secret *sidecred.Credential, config json
 }
 
 // Read implements secretstore.SecretStore.
-func (s *store) Read(path string, _ json.RawMessage) (string, bool, error) {
+func (s *store) Read(ctx context.Context, path string, _ json.RawMessage) (string, bool, error) {
 	v, ok := s.secrets[path]
 	if !ok {
 		return "", false, nil
@@ -69,7 +70,7 @@ func (s *store) Read(path string, _ json.RawMessage) (string, bool, error) {
 }
 
 // Delete implements secretstore.SecretStore.
-func (s *store) Delete(path string, _ json.RawMessage) error {
+func (s *store) Delete(ctx context.Context, path string, _ json.RawMessage) error {
 	delete(s.secrets, path)
 	return nil
 }

--- a/store/inprocess/inprocess_test.go
+++ b/store/inprocess/inprocess_test.go
@@ -1,6 +1,7 @@
 package inprocess_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -46,16 +47,16 @@ func TestInProcessStore(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			store := secretstore.New(secretstore.WithSecretTemplate(tc.secretTemplate))
 
-			path, err := store.Write(teamName, secret, tc.config)
+			path, err := store.Write(context.TODO(), teamName, secret, tc.config)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.secretPath, path)
 
-			actual, found, err := store.Read(path, nil)
+			actual, found, err := store.Read(context.TODO(), path, nil)
 			assert.Nil(t, err)
 			assert.Equal(t, true, found)
 			assert.Equal(t, secret.Value, actual)
 
-			err = store.Delete(path, nil)
+			err = store.Delete(context.TODO(), path, nil)
 			assert.Nil(t, err)
 		})
 	}

--- a/store/secretsmanager/secretsmanager.go
+++ b/store/secretsmanager/secretsmanager.go
@@ -3,6 +3,7 @@ package secretsmanager
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -57,7 +58,7 @@ func (s *store) Type() sidecred.StoreType {
 }
 
 // Write implements sidecred.SecretStore.
-func (s *store) Write(namespace string, secret *sidecred.Credential, config json.RawMessage) (string, error) {
+func (s *store) Write(ctx context.Context, namespace string, secret *sidecred.Credential, config json.RawMessage) (string, error) {
 	c, err := s.parseConfig(config)
 	if err != nil {
 		return "", fmt.Errorf("parse config: %s", err)
@@ -96,7 +97,7 @@ func (s *store) Write(namespace string, secret *sidecred.Credential, config json
 }
 
 // Read implements sidecred.SecretStore.
-func (s *store) Read(path string, _ json.RawMessage) (string, bool, error) {
+func (s *store) Read(ctx context.Context, path string, _ json.RawMessage) (string, bool, error) {
 	out, err := s.client.GetSecretValue(&secretsmanager.GetSecretValueInput{
 		SecretId: aws.String(path),
 	})
@@ -115,7 +116,7 @@ func (s *store) Read(path string, _ json.RawMessage) (string, bool, error) {
 }
 
 // Delete implements sidecred.SecretStore.
-func (s *store) Delete(path string, _ json.RawMessage) error {
+func (s *store) Delete(ctx context.Context, path string, _ json.RawMessage) error {
 	_, err := s.client.DeleteSecret(&secretsmanager.DeleteSecretInput{
 		SecretId:                   aws.String(path),
 		ForceDeleteWithoutRecovery: aws.Bool(true),

--- a/store/secretsmanager/secretsmanager_test.go
+++ b/store/secretsmanager/secretsmanager_test.go
@@ -1,6 +1,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -89,7 +90,7 @@ func TestWrite(t *testing.T) {
 			client.UpdateSecretReturns(nil, tc.updateError)
 
 			store := secretstore.New(client, secretstore.WithSecretTemplate(tc.secretTemplate))
-			path, err := store.Write(teamName, secret, tc.config)
+			path, err := store.Write(context.TODO(), teamName, secret, tc.config)
 
 			assert.Equal(t, tc.expectedError, err)
 			assert.Equal(t, tc.secretPath, path)
@@ -144,7 +145,7 @@ func TestRead(t *testing.T) {
 			client.GetSecretValueReturns(tc.getSecretOutput, tc.getSecretError)
 
 			store := secretstore.New(client)
-			secret, found, err := store.Read(tc.secretPath, nil)
+			secret, found, err := store.Read(context.TODO(), tc.secretPath, nil)
 
 			assert.Equal(t, tc.expectedError, err)
 			assert.Equal(t, tc.expectFound, found)
@@ -187,7 +188,7 @@ func TestDelete(t *testing.T) {
 			client.DeleteSecretReturns(nil, tc.deleteSecretError)
 
 			store := secretstore.New(client)
-			err := store.Delete(tc.secretPath, nil)
+			err := store.Delete(context.TODO(), tc.secretPath, nil)
 
 			assert.Equal(t, tc.expectedError, err)
 			assert.Equal(t, 1, client.DeleteSecretCallCount())

--- a/store/ssm/ssm.go
+++ b/store/ssm/ssm.go
@@ -3,6 +3,7 @@ package ssm
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -66,7 +67,7 @@ func (s *store) Type() sidecred.StoreType {
 }
 
 // Write implements sidecred.SecretStore.
-func (s *store) Write(namespace string, secret *sidecred.Credential, config json.RawMessage) (string, error) {
+func (s *store) Write(ctx context.Context, namespace string, secret *sidecred.Credential, config json.RawMessage) (string, error) {
 	c, err := s.parseConfig(config)
 	if err != nil {
 		return "", fmt.Errorf("parse config: %s", err)
@@ -95,7 +96,7 @@ func (s *store) Write(namespace string, secret *sidecred.Credential, config json
 }
 
 // Read implements sidecred.SecretStore.
-func (s *store) Read(path string, _ json.RawMessage) (string, bool, error) {
+func (s *store) Read(ctx context.Context, path string, _ json.RawMessage) (string, bool, error) {
 	out, err := s.client.GetParameter(&ssm.GetParameterInput{
 		Name:           aws.String(path),
 		WithDecryption: aws.Bool(true),
@@ -115,7 +116,7 @@ func (s *store) Read(path string, _ json.RawMessage) (string, bool, error) {
 }
 
 // Delete implements sidecred.SecretStore.
-func (s *store) Delete(path string, _ json.RawMessage) error {
+func (s *store) Delete(ctx context.Context, path string, _ json.RawMessage) error {
 	_, err := s.client.DeleteParameter(&ssm.DeleteParameterInput{
 		Name: aws.String(path),
 	})

--- a/store/ssm/ssm_test.go
+++ b/store/ssm/ssm_test.go
@@ -1,6 +1,7 @@
 package ssm_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -61,7 +62,7 @@ func TestWrite(t *testing.T) {
 			client.PutParameterReturns(nil, tc.putError)
 
 			store := secretstore.New(client, secretstore.WithSecretTemplate(tc.secretTemplate))
-			path, err := store.Write(teamName, secret, tc.config)
+			path, err := store.Write(context.TODO(), teamName, secret, tc.config)
 
 			assert.Equal(t, tc.expectedError, err)
 			assert.Equal(t, tc.secretPath, path)
@@ -117,7 +118,7 @@ func TestRead(t *testing.T) {
 			client.GetParameterReturns(tc.getParameterOutput, tc.getParameterError)
 
 			store := secretstore.New(client)
-			secret, found, err := store.Read(tc.secretPath, nil)
+			secret, found, err := store.Read(context.TODO(), tc.secretPath, nil)
 
 			assert.Equal(t, tc.expectedError, err)
 			assert.Equal(t, tc.expectFound, found)
@@ -160,7 +161,7 @@ func TestDelete(t *testing.T) {
 			client.DeleteParameterReturns(nil, tc.deleteParameterError)
 
 			store := secretstore.New(client)
-			err := store.Delete(tc.secretPath, nil)
+			err := store.Delete(context.TODO(), tc.secretPath, nil)
 
 			assert.Equal(t, tc.expectedError, err)
 			assert.Equal(t, 1, client.DeleteParameterCallCount())


### PR DESCRIPTION
This PR adds the following,
* A golang context object to calls, for future timeout handling, and carrying request data.
* A logger to the context object, for easier logging in all the code.
* A stats object to the context object, for easier collection of statistics.
* A trace_id to the logs, for connecting the logs together in datadog.